### PR TITLE
fix(security): harden debug auth, CORS, gateway, and config defaults

### DIFF
--- a/clients/grpcc/middleware.go
+++ b/clients/grpcc/middleware.go
@@ -84,6 +84,7 @@ func unaryInterceptor(middlewares []lava.Middleware) grpc.UnaryClientInterceptor
 		// set the timeout if we have it
 		if len(to) != 0 {
 			if dur, err := time.ParseDuration(to[0]); err == nil {
+				dur = grpcutil.CapRequestTimeout(dur)
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithTimeout(ctx, dur)
 				defer cancel()
@@ -163,6 +164,7 @@ func streamInterceptor(middlewares []lava.Middleware) grpc.StreamClientIntercept
 		// set the timeout if we have it
 		if len(to) != 0 {
 			if dur, err := time.ParseDuration(to[0]); err == nil {
+				dur = grpcutil.CapRequestTimeout(dur)
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithTimeout(ctx, dur)
 				defer cancel()

--- a/core/debug/debug/mux.go
+++ b/core/debug/debug/mux.go
@@ -67,7 +67,7 @@ func ensurePassword() {
 	}
 	passwd = hex.EncodeToString(b)
 	log.Warn().
-		Str("env", running.Env.String()).
+		Str("env", running.EnvName()).
 		Msg("debug: no debug.password configured; set debug.password in config (auto-generated password active)")
 }
 

--- a/core/debug/debug/mux.go
+++ b/core/debug/debug/mux.go
@@ -1,13 +1,16 @@
 // Package debug 注册 debug 控制台主页与全局鉴权中间件。
 //
 // 鉴权策略：
-//   - 来自 localhost / 127.0.0.1 / ::1 的请求免 token
+//   - 来自 loopback 地址（127.0.0.1 / ::1）的请求免 token（基于客户端 IP，非 Host 头）
 //   - 其他来源须通过 query ?token=、Header token/Authorization 或 Cookie 携带有效 token
-//   - 默认 token 为 running.InstanceID，可通过配置文件 debug.password 覆盖
+//   - 默认 token 启动时随机生成，可通过配置文件 debug.password 覆盖
 package debug
 
 import (
+	"crypto/rand"
 	"crypto/subtle"
+	"encoding/hex"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -20,6 +23,7 @@ import (
 	"github.com/pubgo/funk/v2/log"
 	"github.com/pubgo/funk/v2/recovery"
 	"github.com/pubgo/funk/v2/strutil"
+	"github.com/rs/xid"
 	"github.com/valyala/fasthttp"
 	"gopkg.in/yaml.v3"
 
@@ -28,28 +32,43 @@ import (
 )
 
 var (
-	passwd    = running.InstanceID
+	passwd    string
 	once      sync.Once
 	configErr error
 	startTime = time.Now()
 )
-
-// 允许访问的本地 IP 列表
-var localHosts = map[string]bool{
-	"localhost": true,
-	"127.0.0.1": true,
-	"::1":       true,
-}
 
 // secureCompare 使用常量时间比较防止时序攻击
 func secureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
-// isLocalHost 检查是否为本地访问
-func isLocalHost(host string) bool {
-	host = strings.Split(host, ":")[0]
-	return localHosts[host]
+// isLocalClient reports whether the request originates from a loopback address.
+// Host header is intentionally not used — it is client-controlled and must not
+// influence auth decisions.
+func isLocalClient(c fiber.Ctx) bool {
+	return isLoopbackIP(c.IP())
+}
+
+func isLoopbackIP(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	return ip != nil && ip.IsLoopback()
+}
+
+func ensurePassword() {
+	if passwd != "" {
+		return
+	}
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		passwd = xid.New().String()
+		log.Warn().Err(err).Msg("debug: failed to generate random password, using fallback")
+		return
+	}
+	passwd = hex.EncodeToString(b)
+	log.Warn().
+		Str("env", running.Env.String()).
+		Msg("debug: no debug.password configured; set debug.password in config (auto-generated password active)")
 }
 
 // loadConfig 加载配置（只执行一次）
@@ -57,7 +76,8 @@ func loadConfig() {
 	once.Do(func() {
 		configPath := config.GetConfigPath()
 		if configPath == "" {
-			log.Warn().Msg("debug: config path is empty, using default password")
+			log.Warn().Msg("debug: config path is empty, using auto-generated password")
+			ensurePassword()
 			return
 		}
 
@@ -77,7 +97,9 @@ func loadConfig() {
 
 		if cfg.Debug.Password != "" {
 			passwd = cfg.Debug.Password
+			return
 		}
+		ensurePassword()
 	})
 }
 
@@ -110,9 +132,10 @@ func init() {
 
 		// 加载配置
 		loadConfig()
+		ensurePassword()
 
-		// 非本地访问需要验证 token
-		if !isLocalHost(c.Hostname()) {
+		// 非 loopback 访问需要验证 token
+		if !isLocalClient(c) {
 			if !secureCompare(token, passwd) {
 				log.Warn().
 					Str("ip", c.IP()).
@@ -140,9 +163,9 @@ func init() {
 				c.Response().Header.SetCookie(cc)
 			}
 
-			// 添加响应头
+			// 添加响应头（request ID 与鉴权 token 分离，不复用 InstanceID）
 			c.Set("X-Debug-Version", "1.0")
-			c.Set("X-Request-ID", running.InstanceID)
+			c.Set("X-Request-ID", xid.New().String())
 		}
 
 		log.Debug().

--- a/core/debug/debug/mux_test.go
+++ b/core/debug/debug/mux_test.go
@@ -1,0 +1,33 @@
+package debug
+
+import "testing"
+
+func TestIsLoopbackIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"10.0.0.1", false},
+		{"192.168.1.1", false},
+		{"", false},
+		{"not-an-ip", false},
+	}
+
+	for _, tt := range tests {
+		if got := isLoopbackIP(tt.ip); got != tt.want {
+			t.Fatalf("isLoopbackIP(%q) = %v, want %v", tt.ip, got, tt.want)
+		}
+	}
+}
+
+func TestIsLoopbackIPRejectsPublicIP(t *testing.T) {
+	t.Parallel()
+
+	if isLoopbackIP("8.8.8.8") {
+		t.Fatal("non-loopback IP must not bypass auth")
+	}
+}

--- a/core/debug/mux.go
+++ b/core/debug/mux.go
@@ -4,9 +4,8 @@
 // 向全局 App 注册路由；主 HTTP/gRPC 服务器通过 app.Use("/debug", debug.App()) 挂载。
 //
 // 鉴权由 debug/debug 子包的全局中间件负责：
-//   - localhost / 127.0.0.1 / ::1 访问免鉴权
-//   - 非本地访问需携带 token（query/header/cookie），默认密码为 InstanceID，
-//     可在配置文件的 debug.password 字段覆盖
+//   - 来自 loopback 地址（127.0.0.1 / ::1）的请求免 token（基于客户端 IP）
+//   - 非本地访问需携带 token（query/header/cookie），可在配置 debug.password 中设置
 package debug
 
 import (

--- a/core/running/env.go
+++ b/core/running/env.go
@@ -1,0 +1,47 @@
+package running
+
+// Well-known runtime environment names (see EnvFlag / --runenv).
+const (
+	EnvDev   = "dev"
+	EnvTest  = "test"
+	EnvStage = "stage" // staging
+	EnvProd  = "prod"
+)
+
+// EnvNames lists all supported environment values in promotion order.
+var EnvNames = []string{EnvDev, EnvTest, EnvStage, EnvProd}
+
+// EnvName returns the current runtime environment.
+func EnvName() string {
+	return Env.String()
+}
+
+// IsDev reports whether the process runs in the development environment.
+func IsDev() bool {
+	return EnvName() == EnvDev
+}
+
+// IsTest reports whether the process runs in the test environment.
+func IsTest() bool {
+	return EnvName() == EnvTest
+}
+
+// IsStage reports whether the process runs in the staging environment.
+func IsStage() bool {
+	return EnvName() == EnvStage
+}
+
+// IsProd reports whether the process runs in the production environment.
+func IsProd() bool {
+	return EnvName() == EnvProd
+}
+
+// IsNonProd reports whether the process runs outside production.
+func IsNonProd() bool {
+	switch EnvName() {
+	case EnvDev, EnvTest, EnvStage:
+		return true
+	default:
+		return false
+	}
+}

--- a/core/running/env_test.go
+++ b/core/running/env_test.go
@@ -1,0 +1,44 @@
+package running
+
+import "testing"
+
+func TestEnvHelpers(t *testing.T) {
+	orig := Env.String()
+	t.Cleanup(func() { _ = Env.Set(orig) })
+
+	cases := []struct {
+		env           string
+		dev           bool
+		test          bool
+		stage         bool
+		prod          bool
+		nonProd       bool
+	}{
+		{EnvDev, true, false, false, false, true},
+		{EnvTest, false, true, false, false, true},
+		{EnvStage, false, false, true, false, true},
+		{EnvProd, false, false, false, true, false},
+		{"custom", false, false, false, false, false},
+	}
+
+	for _, tc := range cases {
+		if err := Env.Set(tc.env); err != nil {
+			t.Fatalf("Env.Set(%q): %v", tc.env, err)
+		}
+		if got := IsDev(); got != tc.dev {
+			t.Fatalf("IsDev()@%s = %v, want %v", tc.env, got, tc.dev)
+		}
+		if got := IsTest(); got != tc.test {
+			t.Fatalf("IsTest()@%s = %v, want %v", tc.env, got, tc.test)
+		}
+		if got := IsStage(); got != tc.stage {
+			t.Fatalf("IsStage()@%s = %v, want %v", tc.env, got, tc.stage)
+		}
+		if got := IsProd(); got != tc.prod {
+			t.Fatalf("IsProd()@%s = %v, want %v", tc.env, got, tc.prod)
+		}
+		if got := IsNonProd(); got != tc.nonProd {
+			t.Fatalf("IsNonProd()@%s = %v, want %v", tc.env, got, tc.nonProd)
+		}
+	}
+}

--- a/core/running/running.go
+++ b/core/running/running.go
@@ -27,8 +27,8 @@ import (
 )
 
 var (
-	// Env 是当前运行环境，默认 "dev"。
-	Env = redant.StringOf(lo.ToPtr("dev"))
+	// Env 是当前运行环境，默认 EnvDev（dev/test/stage/prod，见 EnvNames）。
+	Env = redant.StringOf(lo.ToPtr(EnvDev))
 	// Debug 是否启用 debug 模式。
 	Debug = redant.BoolOf(lo.ToPtr(false))
 	// HttpPort 是默认 HTTP 监听端口。
@@ -87,7 +87,7 @@ var (
 
 	EnvFlag = redant.Option{
 		Flag:        "runenv",
-		Description: "running env, dev,test,stage,prod",
+		Description: "running env: dev, test, stage (staging), prod",
 		Value:       Env,
 		Default:     Env.String(),
 		Envs:        []string{env.Key("env"), env.Key("runenv")},

--- a/internal/configs/envs/envs.yaml
+++ b/internal/configs/envs/envs.yaml
@@ -3,25 +3,25 @@ OPENAI_API_KEY:
   validate: "required"
 OPENAI_BASE_URL:
   desc: "OpenAI Base URL"
-  default: "https://api.deepseek.com/v1"
+  default: "https://api.example.com/v1"
 OPENAI_MODEL:
   desc: "OpenAI Model"
-  default: "deepseek-chat"
+  default: "example-model"
 ENABLE_DEBUG:
   desc: "enable debug"
   default: "false"
 DB_DSN:
   desc: "db dsn"
-  default: "host=ec2-3-114-17-139.ap-northeast-1.compute.amazonaws.com dbname=welogin port=15432 user=postgres password=QMDifpRFo3zbN01ySrJg sslmode=disable"
+  default: "host=localhost dbname=app port=5432 user=postgres password=changeme sslmode=disable"
 ENV:
   desc: app env
   default: dev
 CATDOGS_BASIC_AUTH_PASSWD:
   desc: basic auth password
-  default: "123456"
+  default: "changeme"
 GOOGLE_CALLBACK_URL:
   desc: "google callback url"
-  default: "https://travel.chameleontravel.club/chameleon/auth/authorize/google/callback"
+  default: "http://localhost:8080/auth/google/callback"
 LOG_LEVEL:
   desc: "log level"
   default: "debug"
@@ -47,4 +47,4 @@ REDIS_ADDR:
 
 REDIS_PWD:
   desc: redis password
-  default: "123456"
+  default: "changeme"

--- a/pkg/grpcutil/timeout.go
+++ b/pkg/grpcutil/timeout.go
@@ -1,0 +1,21 @@
+package grpcutil
+
+import "time"
+
+const (
+	// MinRequestTimeout is the shortest deadline accepted from client metadata.
+	MinRequestTimeout = 10 * time.Millisecond
+	// MaxRequestTimeout is the longest deadline accepted from client metadata.
+	MaxRequestTimeout = 30 * time.Second
+)
+
+// CapRequestTimeout clamps client-provided RPC deadlines to a safe range.
+func CapRequestTimeout(d time.Duration) time.Duration {
+	if d < MinRequestTimeout {
+		return MinRequestTimeout
+	}
+	if d > MaxRequestTimeout {
+		return MaxRequestTimeout
+	}
+	return d
+}

--- a/pkg/grpcutil/timeout_test.go
+++ b/pkg/grpcutil/timeout_test.go
@@ -1,0 +1,26 @@
+package grpcutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCapRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   time.Duration
+		want time.Duration
+	}{
+		{0, MinRequestTimeout},
+		{time.Millisecond, MinRequestTimeout},
+		{time.Second, time.Second},
+		{time.Hour, MaxRequestTimeout},
+	}
+
+	for _, tt := range tests {
+		if got := CapRequestTimeout(tt.in); got != tt.want {
+			t.Fatalf("CapRequestTimeout(%v) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}

--- a/pkg/httputil/util.go
+++ b/pkg/httputil/util.go
@@ -113,9 +113,8 @@ func Cors() fiber.Handler {
 		MaxAge: 0,
 	}
 
-	// Cross-origin with credentials requires an explicit origin allow-list.
-	// In dev, allow any origin but disable credentials to avoid credentialed CSRF.
-	if running.Env.String() == "dev" || running.Debug.Value() {
+	// In dev/test, allow cross-origin without credentials. Production requires explicit config.
+	if running.IsNonProd() || running.Debug.Value() {
 		cfg.AllowOriginsFunc = func(origin string) bool {
 			return origin != ""
 		}

--- a/pkg/httputil/util.go
+++ b/pkg/httputil/util.go
@@ -100,10 +100,7 @@ func ErrHandler(ctx fiber.Ctx, err error) error {
 }
 
 func Cors() fiber.Handler {
-	return cors.New(cors.Config{
-		AllowOriginsFunc: func(origin string) bool {
-			return true
-		},
+	cfg := cors.Config{
 		AllowMethods: []string{
 			fiber.MethodGet,
 			fiber.MethodPost,
@@ -113,9 +110,20 @@ func Cors() fiber.Handler {
 			fiber.MethodHead,
 			fiber.MethodOptions,
 		},
-		// AllowHeaders:     "",
-		AllowCredentials: true,
-		// ExposeHeaders:    "",
 		MaxAge: 0,
-	})
+	}
+
+	// Cross-origin with credentials requires an explicit origin allow-list.
+	// In dev, allow any origin but disable credentials to avoid credentialed CSRF.
+	if running.Env.String() == "dev" || running.Debug.Value() {
+		cfg.AllowOriginsFunc = func(origin string) bool {
+			return origin != ""
+		}
+	} else {
+		cfg.AllowOriginsFunc = func(origin string) bool {
+			return false
+		}
+	}
+
+	return cors.New(cfg)
 }

--- a/servers/gatewayserver/middleware.go
+++ b/servers/gatewayserver/middleware.go
@@ -8,7 +8,6 @@ import (
 	grpcMiddle "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/pubgo/funk/v2/buildinfo/version"
 	"github.com/pubgo/funk/v2/convert"
-	"github.com/pubgo/funk/v2/errors"
 	"github.com/pubgo/funk/v2/errors/errcode"
 	"github.com/pubgo/funk/v2/log"
 	"github.com/pubgo/funk/v2/proto/errorpb"
@@ -75,6 +74,7 @@ func handlerUnaryMiddle(middlewares map[string][]lava.Middleware) grpc.UnaryServ
 		// set the timeout if we have it
 		if len(to) != 0 && to[0] != "" {
 			if dur, err := time.ParseDuration(to[0]); err == nil {
+				dur = grpcutil.CapRequestTimeout(dur)
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithTimeout(ctx, dur)
 				defer cancel()
@@ -137,7 +137,6 @@ func handlerUnaryMiddle(middlewares map[string][]lava.Middleware) grpc.UnaryServ
 		rsp, err := lava.Chain(middlewares[srvName]...).Middleware(unaryWrapper)(ctx, rpcReq)
 		if err != nil {
 			pb := errcode.ParseError(err)
-			pb.Details = append(pb.Details, errcode.MustTagsToAny(errors.Tags{"reqHeader": string(rpcReq.Header().Header())})...)
 
 			if pb.Message == "" {
 				pb.Message = err.Error()
@@ -193,6 +192,7 @@ func handlerStreamMiddle(middlewares map[string][]lava.Middleware) grpc.StreamSe
 		// set the timeout if we have it
 		if len(to) != 0 {
 			if dur, err := time.ParseDuration(to[0]); err == nil {
+				dur = grpcutil.CapRequestTimeout(dur)
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithTimeout(ctx, dur)
 				defer cancel()

--- a/servers/gatewayserver/server.go
+++ b/servers/gatewayserver/server.go
@@ -217,15 +217,17 @@ func (s *serviceImpl) init(
 	if conf.WebSocketPort > 0 {
 		wsInsecure := conf.WebSocketInsecureSkipVerify
 		if len(conf.WebSocketOriginPatterns) == 0 && !conf.WebSocketInsecureSkipVerify {
-			if running.Env.String() == "dev" {
+			if running.IsDev() || running.IsTest() {
 				wsInsecure = true
 				log.Warn().
 					Int64("port", conf.WebSocketPort).
-					Msg("gateway websocket: no origin_patterns configured, skipping origin verification (dev only; set websocket_origin_patterns in production)")
+					Str("env", running.EnvName()).
+					Msg("gateway websocket: no origin_patterns configured, skipping origin verification (dev/test only; set websocket_origin_patterns in stage/prod)")
 			} else {
 				log.Error().
 					Int64("port", conf.WebSocketPort).
-					Msg("gateway websocket: websocket_origin_patterns required in non-dev environments; origin verification enabled")
+					Str("env", running.EnvName()).
+					Msg("gateway websocket: websocket_origin_patterns required in stage/prod; origin verification enabled")
 			}
 		}
 		wsOpts := gateway.WSOptionsFromConfig(gateway.WSConfig{

--- a/servers/gatewayserver/server.go
+++ b/servers/gatewayserver/server.go
@@ -127,7 +127,6 @@ func (s *serviceImpl) init(
 		log.Debug().
 			Str("path", ctx.Path()).
 			Str("method", ctx.Method()).
-			Str("header", ctx.Request().Header.String()).
 			Msg("gateway router")
 		return ctx.Next()
 	})
@@ -216,15 +215,23 @@ func (s *serviceImpl) init(
 	})
 
 	if conf.WebSocketPort > 0 {
+		wsInsecure := conf.WebSocketInsecureSkipVerify
+		if len(conf.WebSocketOriginPatterns) == 0 && !conf.WebSocketInsecureSkipVerify {
+			if running.Env.String() == "dev" {
+				wsInsecure = true
+				log.Warn().
+					Int64("port", conf.WebSocketPort).
+					Msg("gateway websocket: no origin_patterns configured, skipping origin verification (dev only; set websocket_origin_patterns in production)")
+			} else {
+				log.Error().
+					Int64("port", conf.WebSocketPort).
+					Msg("gateway websocket: websocket_origin_patterns required in non-dev environments; origin verification enabled")
+			}
+		}
 		wsOpts := gateway.WSOptionsFromConfig(gateway.WSConfig{
 			OriginPatterns:     conf.WebSocketOriginPatterns,
-			InsecureSkipVerify: conf.WebSocketInsecureSkipVerify || len(conf.WebSocketOriginPatterns) == 0,
+			InsecureSkipVerify: wsInsecure,
 		})
-		if len(conf.WebSocketOriginPatterns) == 0 && !conf.WebSocketInsecureSkipVerify {
-			log.Warn().
-				Int64("port", conf.WebSocketPort).
-				Msg("gateway websocket: no origin_patterns configured, skipping origin verification (development default; set websocket_origin_patterns in production)")
-		}
 		wsHandler := mux.WebSocketHandler(wsOpts...)
 		s.wsServer = &http.Server{
 			Addr:              fmt.Sprintf(":%d", conf.WebSocketPort),


### PR DESCRIPTION
Close P0 security issues: use loopback client IP for debug auth instead of spoofable Host header, stop leaking request headers in gRPC errors and logs, tighten CORS/WebSocket origin policy, cap client RPC timeouts, and replace hardcoded credentials in envs.yaml with safe placeholders.