### PR TITLE
fix: tests, tunnel waits, body limit, shared agent service

### DIFF
--- a/cmds/schedulercmd/cmd.go
+++ b/cmds/schedulercmd/cmd.go
@@ -84,7 +84,7 @@ func New(di *dix.Dix) *redant.Command {
 			// 注册到 tunneldebug，可以在 /debug/tunnel 查看 Agent 状态
 			// 实际启动交由 supervisor 生命周期统一管理，避免重复 Start
 			tunneldebug.SetAgent(agent)
-			assert.Exit(manager.Add(&tunnelAgentService{agent: agent}))
+			assert.Exit(manager.Add(tunnelagent.NewSupervisorService(agent)))
 			log.Info().
 				Str("gateway", gatewayAddr).
 				Str("service", serviceName).
@@ -93,55 +93,4 @@ func New(di *dix.Dix) *redant.Command {
 			return manager.Run(ctx)
 		},
 	}
-}
-
-// tunnelAgentService 包装 Agent 为 supervisor.Service
-type tunnelAgentService struct {
-	agent tunnel.Agent
-	err   error
-}
-
-func (s *tunnelAgentService) Name() string {
-	return "tunnel-agent"
-}
-
-func (s *tunnelAgentService) Error() error {
-	return s.err
-}
-
-func (s *tunnelAgentService) String() string {
-	return "Tunnel Agent Service - connects to gateway and exposes local services"
-}
-
-func (s *tunnelAgentService) Serve(ctx context.Context) error {
-	log.Info().Msg("Starting Tunnel Agent...")
-	if err := s.agent.Start(ctx); err != nil {
-		s.err = err
-		return err
-	}
-
-	// 等待上下文取消
-	<-ctx.Done()
-
-	log.Info().Msg("Stopping Tunnel Agent...")
-	return s.agent.Stop(context.Background())
-}
-
-func (s *tunnelAgentService) Metric() *supervisor.Metric {
-	m := &supervisor.Metric{Name: s.Name()}
-	if s.err != nil {
-		m.Status = supervisor.StatusError
-		m.LastError = s.err.Error()
-		return m
-	}
-
-	switch s.agent.Status() {
-	case tunnel.StatusConnected:
-		m.Status = supervisor.StatusRunning
-	case tunnel.StatusConnecting, tunnel.StatusReconnecting:
-		m.Status = supervisor.StatusCrashing
-	default:
-		m.Status = supervisor.StatusStopped
-	}
-	return m
 }

--- a/cmds/tunnelcmd/agent.go
+++ b/cmds/tunnelcmd/agent.go
@@ -74,7 +74,7 @@ func newAgentCommand(di *dix.Dix) *redant.Command {
 			}
 
 			tunneldebug.SetAgent(agent)
-			assert.Exit(manager.Add(&tunnelAgentService{agent: agent}))
+			assert.Exit(manager.Add(tunnelagent.NewSupervisorService(agent)))
 
 			peerID := p2p.PeerIDFromEnv()
 			if peerID != "" {
@@ -121,46 +121,4 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
-}
-
-type tunnelAgentService struct {
-	agent tunnel.Agent
-	err   error
-}
-
-func (s *tunnelAgentService) Name() string { return "tunnel-agent" }
-
-func (s *tunnelAgentService) Error() error { return s.err }
-
-func (s *tunnelAgentService) String() string {
-	return "Tunnel Agent Service - connects to gateway"
-}
-
-func (s *tunnelAgentService) Serve(ctx context.Context) error {
-	log.Info().Msg("Starting Tunnel Agent...")
-	if err := s.agent.Start(ctx); err != nil {
-		s.err = err
-		return err
-	}
-	<-ctx.Done()
-	log.Info().Msg("Stopping Tunnel Agent...")
-	return s.agent.Stop(context.Background())
-}
-
-func (s *tunnelAgentService) Metric() *supervisor.Metric {
-	m := &supervisor.Metric{Name: s.Name()}
-	if s.err != nil {
-		m.Status = supervisor.StatusError
-		m.LastError = s.err.Error()
-		return m
-	}
-	switch s.agent.Status() {
-	case tunnel.StatusConnected:
-		m.Status = supervisor.StatusRunning
-	case tunnel.StatusConnecting, tunnel.StatusReconnecting:
-		m.Status = supervisor.StatusCrashing
-	default:
-		m.Status = supervisor.StatusStopped
-	}
-	return m
 }

--- a/core/tunnel/integration_test.go
+++ b/core/tunnel/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/pubgo/lava/v2/core/tunnel"
+	"github.com/pubgo/lava/v2/core/tunnel/testhelper"
 	_ "github.com/pubgo/lava/v2/core/tunnel/kcp"
 	_ "github.com/pubgo/lava/v2/core/tunnel/quic"
 	"github.com/pubgo/lava/v2/core/tunnel/tunnelagent"
@@ -53,12 +54,14 @@ func runTransportTest(t *testing.T, transport string, basePort int) {
 			t.Logf("backend server error: %v", err)
 		}
 	}()
-	t.Cleanup(func() {
+		t.Cleanup(func() {
 		if err := backendSrv.Shutdown(ctx); err != nil {
 			t.Logf("backend shutdown failed: %v", err)
 		}
 	})
-	time.Sleep(100 * time.Millisecond)
+	if err := testhelper.WaitTCP(ctx, backendAddr); err != nil {
+		t.Fatalf("[%s] backend: %v", transport, err)
+	}
 
 	gw := tunnelgateway.New(&tunnelgateway.Config{
 		ListenAddr:       gatewayAddr,
@@ -90,10 +93,8 @@ func runTransportTest(t *testing.T, transport string, basePort int) {
 			t.Logf("[%s] Agent stop failed: %v", transport, err)
 		}
 	})
-	time.Sleep(500 * time.Millisecond)
-
-	if len(gw.Services()) == 0 {
-		t.Fatalf("[%s] No services", transport)
+	if err := testhelper.WaitServiceCount(ctx, 1, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatalf("[%s] register: %v", transport, err)
 	}
 
 	resp, err := http.Get(proxyAddr + "/" + transport + "-svc/hello")
@@ -141,7 +142,11 @@ func TestAgentProxy_MultiBackends(t *testing.T) {
 			}
 		})
 	}
-	time.Sleep(100 * time.Millisecond)
+	for i := 1; i <= 3; i++ {
+		if err := testhelper.WaitTCP(ctx, fmt.Sprintf("127.0.0.1:%d", 21080+i)); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	gw := tunnelgateway.New(&tunnelgateway.Config{
 		ListenAddr: "127.0.0.1:21000",
@@ -177,7 +182,9 @@ func TestAgentProxy_MultiBackends(t *testing.T) {
 			}
 		}
 	}()
-	time.Sleep(500 * time.Millisecond)
+	if err := testhelper.WaitServiceCount(ctx, 3, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatal(err)
+	}
 
 	for i := 1; i <= 3; i++ {
 		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:21080/svc-%d/api", i))
@@ -215,12 +222,14 @@ func TestAgentProxy_POST(t *testing.T) {
 			t.Logf("backend server error: %v", err)
 		}
 	}()
-	t.Cleanup(func() {
+		t.Cleanup(func() {
 		if err := srv.Shutdown(ctx); err != nil {
 			t.Logf("backend shutdown failed: %v", err)
 		}
 	})
-	time.Sleep(100 * time.Millisecond)
+	if err := testhelper.WaitTCP(ctx, "127.0.0.1:22081"); err != nil {
+		t.Fatal(err)
+	}
 
 	gw := tunnelgateway.New(&tunnelgateway.Config{ListenAddr: "127.0.0.1:22000", Transport: "yamux", HTTPPort: 22080})
 	if err := gw.Start(ctx); err != nil {
@@ -241,12 +250,14 @@ func TestAgentProxy_POST(t *testing.T) {
 	if err := agent.Start(ctx); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
+		t.Cleanup(func() {
 		if err := agent.Stop(ctx); err != nil {
 			t.Logf("agent stop failed: %v", err)
 		}
 	})
-	time.Sleep(500 * time.Millisecond)
+	if err := testhelper.WaitServiceCount(ctx, 1, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatal(err)
+	}
 
 	resp, err := http.Post("http://127.0.0.1:22080/post-svc/echo", "application/json", strings.NewReader(`{"test":"data"}`))
 	if err != nil {
@@ -293,7 +304,9 @@ func TestAgentProxy_LargeBody(t *testing.T) {
 			t.Logf("backend shutdown failed: %v", err)
 		}
 	})
-	time.Sleep(100 * time.Millisecond)
+	if err := testhelper.WaitTCP(ctx, "127.0.0.1:23081"); err != nil {
+		t.Fatal(err)
+	}
 
 	gw := tunnelgateway.New(&tunnelgateway.Config{ListenAddr: "127.0.0.1:23000", Transport: "yamux", HTTPPort: 23080})
 	if err := gw.Start(ctx); err != nil {
@@ -319,7 +332,9 @@ func TestAgentProxy_LargeBody(t *testing.T) {
 			t.Logf("agent stop failed: %v", err)
 		}
 	})
-	time.Sleep(500 * time.Millisecond)
+	if err := testhelper.WaitServiceCount(ctx, 1, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, size := range []int{1024, 10 * 1024, 100 * 1024} {
 		t.Run(fmt.Sprintf("%dKB", size/1024), func(t *testing.T) {
@@ -374,7 +389,9 @@ func TestAgentProxy_Concurrent(t *testing.T) {
 			t.Logf("backend shutdown failed: %v", err)
 		}
 	})
-	time.Sleep(100 * time.Millisecond)
+	if err := testhelper.WaitTCP(ctx, "127.0.0.1:24081"); err != nil {
+		t.Fatal(err)
+	}
 
 	gw := tunnelgateway.New(&tunnelgateway.Config{ListenAddr: "127.0.0.1:24000", Transport: "yamux", HTTPPort: 24080})
 	if err := gw.Start(ctx); err != nil {
@@ -400,7 +417,9 @@ func TestAgentProxy_Concurrent(t *testing.T) {
 			t.Logf("agent stop failed: %v", err)
 		}
 	})
-	time.Sleep(500 * time.Millisecond)
+	if err := testhelper.WaitServiceCount(ctx, 1, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatal(err)
+	}
 
 	n := 50
 	var wg sync.WaitGroup
@@ -486,7 +505,9 @@ func TestAgentProxy_TCP(t *testing.T) {
 			t.Logf("agent stop failed: %v", err)
 		}
 	})
-	time.Sleep(500 * time.Millisecond)
+	if err := testhelper.WaitServiceCount(ctx, 1, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatal(err)
+	}
 
 	if len(gw.Services()) == 0 {
 		t.Fatal("no services")
@@ -528,6 +549,9 @@ func TestMultipleAgents(t *testing.T) {
 			}
 		}()
 		servers = append(servers, srv)
+		if err := testhelper.WaitTCP(ctx, fmt.Sprintf("127.0.0.1:%d", port)); err != nil {
+			t.Fatal(err)
+		}
 
 		agent := tunnelagent.New(&tunnelagent.Config{
 			GatewayAddr: "127.0.0.1:27000",
@@ -552,7 +576,9 @@ func TestMultipleAgents(t *testing.T) {
 			}
 		}
 	}()
-	time.Sleep(1 * time.Second)
+	if err := testhelper.WaitServiceCount(ctx, n, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatal(err)
+	}
 
 	if len(gw.Services()) != n {
 		t.Errorf("expected %d services, got %d", n, len(gw.Services()))
@@ -592,7 +618,9 @@ func TestProxyAuth_HTTP(t *testing.T) {
 	backend := &http.Server{Addr: backendAddr, Handler: mux}
 	go func() { _ = backend.ListenAndServe() }()
 	defer func() { _ = backend.Close() }()
-	time.Sleep(100 * time.Millisecond)
+	if err := testhelper.WaitTCP(ctx, backendAddr); err != nil {
+		t.Fatal(err)
+	}
 
 	gw := tunnelgateway.NewGateway(&tunnel.GatewayConfig{
 		ListenAddr: gatewayAddr,
@@ -617,7 +645,9 @@ func TestProxyAuth_HTTP(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = agent.Stop(context.Background()) }()
-	time.Sleep(500 * time.Millisecond)
+	if err := testhelper.WaitServiceCount(ctx, 1, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatal(err)
+	}
 
 	proxyBase := fmt.Sprintf("http://127.0.0.1:%d", proxyPort)
 	resp, err := http.Get(proxyBase + "/auth-svc/ok")
@@ -676,7 +706,9 @@ func TestGRPCProxy_HealthCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = agent.Stop(context.Background()) }()
-	time.Sleep(500 * time.Millisecond)
+	if err := testhelper.WaitServiceCount(ctx, 1, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatal(err)
+	}
 
 	cc, client, err := grpcHealthDial(ctx, fmt.Sprintf("127.0.0.1:%d", grpcProxyPort), "grpc-health", token)
 	if err != nil {

--- a/core/tunnel/testhelper/wait.go
+++ b/core/tunnel/testhelper/wait.go
@@ -1,0 +1,73 @@
+// Package testhelper provides polling helpers for tunnel integration tests.
+package testhelper
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+const pollInterval = 25 * time.Millisecond
+
+// WaitTCP dials addr until the listener accepts or ctx is cancelled.
+func WaitTCP(ctx context.Context, addr string) error {
+	var d net.Dialer
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		conn, err := d.DialContext(ctx, "tcp", addr)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait tcp %s: %w", addr, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// WaitHTTPGET polls url until GET returns nil error or ctx is cancelled.
+func WaitHTTPGET(ctx context.Context, url string) error {
+	client := &http.Client{Timeout: 2 * time.Second}
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait http get %s: %w", url, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// WaitServiceCount polls countFn until it returns at least min or ctx is cancelled.
+func WaitServiceCount(ctx context.Context, min int, countFn func() int) error {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		if countFn() >= min {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait service count >= %d (got %d): %w", min, countFn(), ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}

--- a/core/tunnel/testhelper/wait_test.go
+++ b/core/tunnel/testhelper/wait_test.go
@@ -1,0 +1,40 @@
+package testhelper
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWaitTCP(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := WaitTCP(ctx, ln.Addr().String()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWaitServiceCount(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var n atomic.Int32
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		n.Store(2)
+	}()
+
+	if err := WaitServiceCount(ctx, 2, func() int { return int(n.Load()) }); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/core/tunnel/tunnelagent/standalone_test.go
+++ b/core/tunnel/tunnelagent/standalone_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pubgo/lava/v2/core/tunnel"
+	"github.com/pubgo/lava/v2/core/tunnel/testhelper"
 	"github.com/pubgo/lava/v2/core/tunnel/tunnelagent"
 	"github.com/pubgo/lava/v2/core/tunnel/tunnelgateway"
 )
@@ -24,7 +25,9 @@ func TestStandaloneHTTPProxy(t *testing.T) {
 	}
 	go func() { _ = backend.ListenAndServe() }()
 	defer func() { _ = backend.Close() }()
-	time.Sleep(100 * time.Millisecond)
+	if err := testhelper.WaitTCP(ctx, backend.Addr); err != nil {
+		t.Fatal(err)
+	}
 
 	gwAddr := "127.0.0.1:27280"
 	gw := tunnelgateway.NewGateway(&tunnel.GatewayConfig{
@@ -47,7 +50,9 @@ func TestStandaloneHTTPProxy(t *testing.T) {
 	}
 	defer func() { _ = agent.Stop(context.Background()) }()
 
-	time.Sleep(500 * time.Millisecond)
+	if err := testhelper.WaitServiceCount(ctx, 1, func() int { return len(gw.Services()) }); err != nil {
+		t.Fatal(err)
+	}
 
 	resp, err := tunnel.GetService(nil, "http://127.0.0.1:27282", "standalone-svc", "/", "")
 	if err != nil {

--- a/core/tunnel/tunnelagent/supervisor_service.go
+++ b/core/tunnel/tunnelagent/supervisor_service.go
@@ -1,0 +1,60 @@
+package tunnelagent
+
+import (
+	"context"
+
+	"github.com/pubgo/funk/v2/log"
+
+	"github.com/pubgo/lava/v2/core/supervisor"
+	"github.com/pubgo/lava/v2/core/tunnel"
+)
+
+// SupervisorService wraps a tunnel.Agent as a supervisor.Service.
+type SupervisorService struct {
+	agent tunnel.Agent
+	err   error
+}
+
+// NewSupervisorService returns a supervisor.Service for the given agent.
+func NewSupervisorService(agent tunnel.Agent) *SupervisorService {
+	return &SupervisorService{agent: agent}
+}
+
+func (s *SupervisorService) Name() string { return "tunnel-agent" }
+
+func (s *SupervisorService) Error() error { return s.err }
+
+func (s *SupervisorService) String() string {
+	return "Tunnel Agent Service - connects to gateway and exposes local services"
+}
+
+func (s *SupervisorService) Serve(ctx context.Context) error {
+	log.Info().Msg("Starting Tunnel Agent...")
+	if err := s.agent.Start(ctx); err != nil {
+		s.err = err
+		return err
+	}
+	<-ctx.Done()
+	log.Info().Msg("Stopping Tunnel Agent...")
+	return s.agent.Stop(context.Background())
+}
+
+func (s *SupervisorService) Metric() *supervisor.Metric {
+	m := &supervisor.Metric{Name: s.Name()}
+	if s.err != nil {
+		m.Status = supervisor.StatusError
+		m.LastError = s.err.Error()
+		return m
+	}
+	switch s.agent.Status() {
+	case tunnel.StatusConnected:
+		m.Status = supervisor.StatusRunning
+	case tunnel.StatusConnecting, tunnel.StatusReconnecting:
+		m.Status = supervisor.StatusCrashing
+	default:
+		m.Status = supervisor.StatusStopped
+	}
+	return m
+}
+
+var _ supervisor.Service = (*SupervisorService)(nil)

--- a/pkg/httputil/util.go
+++ b/pkg/httputil/util.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/pubgo/lava/v2/core/encoding/protojson"
+	"github.com/pubgo/lava/v2/core/registry"
 	"github.com/pubgo/lava/v2/core/running"
 	"github.com/pubgo/lava/v2/pkg/fiberbuilder"
 )
@@ -32,7 +33,7 @@ func DefaultCfg(config ...*Config) Config {
 			EnableIPValidation: true,
 			ETag:               true,
 			ErrorHandler:       ErrHandler,
-			BodyLimit:          1024 * 1024 * 500,
+			BodyLimit:          registry.DefaultMaxMsgSize,
 		},
 		EnablePrintRouter: true,
 		HttpPort:          lo.ToPtr(int(running.HttpPort.Value())),

--- a/pkg/httputil/util_test.go
+++ b/pkg/httputil/util_test.go
@@ -1,0 +1,15 @@
+package httputil
+
+import (
+	"testing"
+
+	"github.com/pubgo/lava/v2/core/registry"
+)
+
+func TestDefaultCfgBodyLimit(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultCfg()
+	if cfg.Http.BodyLimit != registry.DefaultMaxMsgSize {
+		t.Fatalf("BodyLimit = %d, want %d", cfg.Http.BodyLimit, registry.DefaultMaxMsgSize)
+	}
+}

--- a/servers/gatewayserver/config_test.go
+++ b/servers/gatewayserver/config_test.go
@@ -1,0 +1,11 @@
+package gatewayserver
+
+import "testing"
+
+func TestDefaultCfgGRPCPassthrough(t *testing.T) {
+	t.Parallel()
+	cfg := defaultCfg()
+	if !cfg.GRPCPassthrough {
+		t.Fatal("expected grpc_passthrough default true")
+	}
+}

--- a/servers/gatewayserver/middleware_test.go
+++ b/servers/gatewayserver/middleware_test.go
@@ -1,0 +1,44 @@
+package gatewayserver
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+
+	"github.com/pubgo/lava/v2/lava"
+)
+
+type testHTTPMiddleware struct {
+	called bool
+}
+
+func (m *testHTTPMiddleware) String() string { return "test-http-mw" }
+
+func (m *testHTTPMiddleware) Middleware(next lava.HandlerFunc) lava.HandlerFunc {
+	return func(ctx context.Context, req lava.Request) (lava.Response, error) {
+		m.called = true
+		return next(ctx, req)
+	}
+}
+
+func TestHandlerHttpMiddleRunsMiddleware(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	mw := &testHTTPMiddleware{}
+	app.Get("/ping", handlerHttpMiddle([]lava.Middleware{mw}))
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/ping", nil))
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusNotFound && resp.StatusCode != fiber.StatusOK {
+		// middleware chain runs before route miss; either OK or 404 is fine
+		t.Logf("status=%d", resp.StatusCode)
+	}
+	if !mw.called {
+		t.Fatal("middleware was not invoked")
+	}
+}

--- a/servers/gatewayserver/util_test.go
+++ b/servers/gatewayserver/util_test.go
@@ -1,0 +1,20 @@
+package gatewayserver
+
+import "testing"
+
+func TestServiceFromMethod(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		method  string
+		service string
+	}{
+		{method: "/echo.Echo/Ping", service: "echo.Echo"},
+		{method: "/pkg.Service/Method", service: "pkg.Service"},
+		{method: "", service: ""},
+	}
+	for _, tt := range tests {
+		if got := serviceFromMethod(tt.method); got != tt.service {
+			t.Fatalf("serviceFromMethod(%q) = %q, want %q", tt.method, got, tt.service)
+		}
+	}
+}

--- a/servers/https/config_test.go
+++ b/servers/https/config_test.go
@@ -1,0 +1,16 @@
+package https
+
+import (
+	"testing"
+
+	"github.com/pubgo/lava/v2/core/registry"
+	"github.com/pubgo/lava/v2/pkg/httputil"
+)
+
+func TestDefaultHTTPConfigBodyLimit(t *testing.T) {
+	t.Parallel()
+	cfg := httputil.DefaultCfg()
+	if cfg.Http.BodyLimit != registry.DefaultMaxMsgSize {
+		t.Fatalf("BodyLimit = %d, want %d", cfg.Http.BodyLimit, registry.DefaultMaxMsgSize)
+	}
+}


### PR DESCRIPTION
## Summary
- **#119**: HTTP default `BodyLimit` 500MB → 4MB (`registry.DefaultMaxMsgSize`, aligned with gRPC)
- **#122**: `core/tunnel/testhelper` polling replaces fixed `time.Sleep` in integration tests
- **#86**: unit tests for `gatewayserver` (util, config, HTTP middleware) and `https` config
- **#96**: `tunnelagent.NewSupervisorService` shared by `schedulercmd` and `tunnelcmd`

## Test plan
- [x] `go test ./... -race -short`

Fixes #86, #96, #119, #122

Made with [Cursor](https://cursor.com)