### PR TITLE
refactor: explicit debug route registration

### DIFF
--- a/core/debug/bootstrap/bootstrap.go
+++ b/core/debug/bootstrap/bootstrap.go
@@ -1,0 +1,45 @@
+// Package bootstrap registers built-in debug routes on the global debug App.
+package bootstrap
+
+import (
+	"sync"
+
+	"github.com/pubgo/lava/v2/core/debug/configview"
+	debugconsole "github.com/pubgo/lava/v2/core/debug/debug"
+	"github.com/pubgo/lava/v2/core/debug/featurehttp"
+	"github.com/pubgo/lava/v2/core/debug/goroutine"
+	"github.com/pubgo/lava/v2/core/debug/healthy"
+	"github.com/pubgo/lava/v2/core/debug/loglevel"
+	"github.com/pubgo/lava/v2/core/debug/pprof"
+	"github.com/pubgo/lava/v2/core/debug/process"
+	"github.com/pubgo/lava/v2/core/debug/ratelimit"
+	"github.com/pubgo/lava/v2/core/debug/runtime"
+	"github.com/pubgo/lava/v2/core/debug/statsviz"
+	"github.com/pubgo/lava/v2/core/debug/sysinfo"
+	"github.com/pubgo/lava/v2/core/debug/trace"
+	"github.com/pubgo/lava/v2/core/debug/vars"
+	"github.com/pubgo/lava/v2/core/debug/version"
+)
+
+var registerOnce sync.Once
+
+// RegisterAll registers built-in debug routes and middleware on debug.App().
+func RegisterAll() {
+	registerOnce.Do(func() {
+		debugconsole.Register()
+		ratelimit.Register()
+		configview.Register()
+		featurehttp.Register()
+		goroutine.Register()
+		healthy.Register()
+		loglevel.Register()
+		pprof.Register()
+		process.Register()
+		runtime.Register()
+		statsviz.Register()
+		sysinfo.Register()
+		trace.Register()
+		vars.Register()
+		version.Register()
+	})
+}

--- a/core/debug/bootstrap/bootstrap_test.go
+++ b/core/debug/bootstrap/bootstrap_test.go
@@ -1,0 +1,24 @@
+package bootstrap_test
+
+import (
+	"testing"
+
+	"github.com/pubgo/lava/v2/core/debug"
+	"github.com/pubgo/lava/v2/core/debug/bootstrap"
+)
+
+func TestRegisterAllIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	bootstrap.RegisterAll()
+	before := len(debug.App().Stack()[0])
+	bootstrap.RegisterAll()
+	after := len(debug.App().Stack()[0])
+
+	if before == 0 {
+		t.Fatal("expected debug routes to be registered")
+	}
+	if after != before {
+		t.Fatalf("RegisterAll registered routes twice: before=%d after=%d", before, after)
+	}
+}

--- a/core/debug/configview/configview.go
+++ b/core/debug/configview/configview.go
@@ -28,7 +28,7 @@ var sensitivePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)connection[_-]?string`),
 }
 
-func init() {
+func Register() {
 	debug.Get("/config", func(ctx fiber.Ctx) error {
 		configPath := config.GetConfigPath()
 

--- a/core/debug/debug/debug.go
+++ b/core/debug/debug/debug.go
@@ -16,11 +16,12 @@ import (
 
 var debugStartTime = time.Now()
 
-func init() {
-	initDebug()
+func Register() {
+	RegisterMiddleware()
+	registerDashboard()
 }
 
-func initDebug() {
+func registerDashboard() {
 	// 主页 - 仪表盘
 	debug.Get("/", func(ctx fiber.Ctx) error {
 		var m runtime.MemStats

--- a/core/debug/debug/mux.go
+++ b/core/debug/debug/mux.go
@@ -103,7 +103,7 @@ func loadConfig() {
 	})
 }
 
-func init() {
+func RegisterMiddleware() {
 	debug.App().Use(func(c fiber.Ctx) (gErr error) {
 		defer recovery.Recovery(func(err error) {
 			err = errors.WrapTags(err, errors.Tags{

--- a/core/debug/featurehttp/featurehttp.go
+++ b/core/debug/featurehttp/featurehttp.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pubgo/lava/v2/core/debug"
 )
 
-func init() {
+func Register() {
 	srv := featurehttp.NewServer("").WithPrefix("/debug/features")
 	debug.App().All("/features", debug.Wrap(srv.Handler()))
 	debug.App().All("/features/*", debug.Wrap(srv.Handler()))

--- a/core/debug/goroutine/goroutine.go
+++ b/core/debug/goroutine/goroutine.go
@@ -28,7 +28,7 @@ type goroutineStat struct {
 	Count     int       `json:"count"`
 }
 
-func init() {
+func Register() {
 	// Goroutine 仪表板 HTML 页面
 	debug.Get("/goroutine", func(ctx fiber.Ctx) error {
 		if ctx.Get("Accept") == "application/json" || ctx.Query("format") == "json" {

--- a/core/debug/healthy/debug.go
+++ b/core/debug/healthy/debug.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pubgo/lava/v2/core/healthy"
 )
 
-func init() {
+func Register() {
 	debug.Get("/health", func(ctx fiber.Ctx) error {
 		dt := make(map[string]*health)
 		allHealthy := true

--- a/core/debug/loglevel/loglevel.go
+++ b/core/debug/loglevel/loglevel.go
@@ -16,7 +16,7 @@ import (
 
 var currentLevel atomic.Value
 
-func init() {
+func Register() {
 	currentLevel.Store(zerolog.GlobalLevel().String())
 
 	debug.Get("/log/level", func(ctx fiber.Ctx) error {

--- a/core/debug/mux.go
+++ b/core/debug/mux.go
@@ -1,7 +1,7 @@
 // Package debug 提供全局 debug HTTP 路由聚合器（基于 Fiber）。
 //
-// 各子模块（pprof、vars、healthy 等）通过 blank import 在 init() 中
-// 向全局 App 注册路由；主 HTTP/gRPC 服务器通过 app.Use("/debug", debug.App()) 挂载。
+// 各子模块通过 debug/bootstrap.RegisterAll() 向全局 App 注册路由；
+// 主 HTTP/gRPC 服务器通过 app.Use("/debug", debug.App()) 挂载。
 //
 // 鉴权由 debug/debug 子包的全局中间件负责：
 //   - 来自 loopback 地址（127.0.0.1 / ::1）的请求免 token（基于客户端 IP）

--- a/core/debug/pprof/pprof.go
+++ b/core/debug/pprof/pprof.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pubgo/lava/v2/core/debug"
 )
 
-func init() {
+func Register() {
 	debug.Get("/gprof/", debug.Wrap(fgprof.Handler()))
 	debug.Route("/pprof/", func(r fiber.Router) {
 		r.Get("", debug.WrapFunc(pprof.Index))

--- a/core/debug/process/process.go
+++ b/core/debug/process/process.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pubgo/lava/v2/core/debug"
 )
 
-func init() {
+func Register() {
 	debug.Get("/process", func(ctx fiber.Ctx) (gErr error) {
 		defer result.RecoveryErr(&gErr)
 		processes := assert.Must1(ps.Processes())

--- a/core/debug/ratelimit/ratelimit.go
+++ b/core/debug/ratelimit/ratelimit.go
@@ -23,7 +23,7 @@ type requestCounter struct {
 	ResetTime time.Time
 }
 
-func init() {
+func Register() {
 	debug.App().Use(rateLimitMiddleware)
 
 	debug.Get("/ratelimit", func(ctx fiber.Ctx) error {

--- a/core/debug/runtime/runtime.go
+++ b/core/debug/runtime/runtime.go
@@ -17,7 +17,7 @@ import (
 
 var runtimeStartTime = time.Now()
 
-func init() {
+func Register() {
 	// Runtime 仪表板 HTML 页面
 	debug.Get("/runtime", func(ctx fiber.Ctx) error {
 		// 如果请求 JSON 格式

--- a/core/debug/statsviz/main.go
+++ b/core/debug/statsviz/main.go
@@ -14,7 +14,7 @@ import (
 
 // github.com/go-echarts/statsview
 
-func init() {
+func Register() {
 	srv := assert.Exit1(statsviz.NewServer(statsviz.Root("/debug/statsviz")))
 	debug.Route("/statsviz", func(router fiber.Router) {
 		router.Use(func(ctx fiber.Ctx) error {

--- a/core/debug/sysinfo/sysinfo.go
+++ b/core/debug/sysinfo/sysinfo.go
@@ -23,7 +23,7 @@ import (
 
 var sysStartTime = time.Now()
 
-func init() {
+func Register() {
 	// 系统信息仪表板 HTML 页面
 	debug.Get("/sys", func(ctx fiber.Ctx) error {
 		vmem, _ := mem.VirtualMemory()

--- a/core/debug/trace/trace.go
+++ b/core/debug/trace/trace.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pubgo/lava/v2/core/debug"
 )
 
-func init() {
+func Register() {
 	debug.Get("/requests", adaptor.HTTPHandlerFunc(trace.Traces))
 	debug.Get("/events", adaptor.HTTPHandlerFunc(trace.Events))
 }

--- a/core/debug/vars/debug.go
+++ b/core/debug/vars/debug.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pubgo/lava/v2/core/debug/ui"
 )
 
-func init() {
+func Register() {
 	defer recovery.Exit()
 
 	debug.Route("/vars", func(r fiber.Router) {

--- a/core/debug/version/version.go
+++ b/core/debug/version/version.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pubgo/lava/v2/core/running"
 )
 
-func init() {
+func Register() {
 	debug.Get("env", adaptor.HTTPHandlerFunc(envHandle))
 	debug.Get("version", adaptor.HTTPHandlerFunc(versionHandle))
 	debug.Get("dep", adaptor.HTTPHandlerFunc(depHandle))

--- a/core/lavabuilder/builder.go
+++ b/core/lavabuilder/builder.go
@@ -2,7 +2,7 @@
 //
 // 它负责：
 //   - 创建 dix 容器并注册默认 Provider（日志、指标、生命周期、服务发现等）
-//   - 通过 blank import 加载编解码器、debug 端点、日志扩展等 side-effect 模块
+//   - 通过 debug.RegisterAll() 加载编解码器、debug 端点、日志扩展等 side-effect 模块
 //   - 注册所有子命令（grpc/http/scheduler/tunnel 等）并挂载全局 CLI flag
 //   - 绑定 signals.Context() 作为根 context，实现优雅关停
 //
@@ -36,22 +36,8 @@ import (
 	"github.com/pubgo/lava/v2/cmds/tunnelcmd"
 	"github.com/pubgo/lava/v2/cmds/versioncmd"
 	"github.com/pubgo/lava/v2/cmds/watchcmd"
-	_ "github.com/pubgo/lava/v2/core/debug/configview"
-	_ "github.com/pubgo/lava/v2/core/debug/debug"
+	debugbootstrap "github.com/pubgo/lava/v2/core/debug/bootstrap"
 	"github.com/pubgo/lava/v2/core/debug/dixdebug"
-	_ "github.com/pubgo/lava/v2/core/debug/featurehttp"
-	_ "github.com/pubgo/lava/v2/core/debug/goroutine"
-	_ "github.com/pubgo/lava/v2/core/debug/healthy"
-	_ "github.com/pubgo/lava/v2/core/debug/loglevel"
-	_ "github.com/pubgo/lava/v2/core/debug/pprof"
-	_ "github.com/pubgo/lava/v2/core/debug/process"
-	_ "github.com/pubgo/lava/v2/core/debug/ratelimit"
-	_ "github.com/pubgo/lava/v2/core/debug/runtime"
-	_ "github.com/pubgo/lava/v2/core/debug/statsviz"
-	_ "github.com/pubgo/lava/v2/core/debug/sysinfo"
-	_ "github.com/pubgo/lava/v2/core/debug/trace"
-	_ "github.com/pubgo/lava/v2/core/debug/vars"
-	_ "github.com/pubgo/lava/v2/core/debug/version"
 	"github.com/pubgo/lava/v2/core/discovery"
 	_ "github.com/pubgo/lava/v2/core/encoding/protobuf"
 	_ "github.com/pubgo/lava/v2/core/encoding/protojson"
@@ -88,6 +74,7 @@ func New(opts ...dix.Option) *dix.Dix {
 	}
 
 	dixdebug.Init(di)
+	debugbootstrap.RegisterAll()
 	return di
 }
 


### PR DESCRIPTION
## Summary
- Replace 15 blank imports in `lavabuilder` with explicit `debug/bootstrap.RegisterAll()`
- Convert debug submodule `init()` hooks to exported `Register()` functions
- Add `core/debug/bootstrap` to wire modules in a fixed order (avoids import cycles)

Closes #100

## Test plan
- [x] `go test ./... -race -short`
- [x] `go test ./core/debug/bootstrap/...` (idempotent RegisterAll)
- [ ] Smoke `/debug/` dashboard on grpc/http server


Made with [Cursor](https://cursor.com)