### PR TITLE
test: add unit tests for grpcc, wsproxy, pkg/middleware (#112)

### DIFF
--- a/clients/grpcc/grpccresolver/util_test.go
+++ b/clients/grpcc/grpccresolver/util_test.go
@@ -1,0 +1,48 @@
+package grpccresolver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDirectTarget(t *testing.T) {
+	t.Parallel()
+
+	got := BuildDirectTarget("mysvc", "127.0.0.1:8080", "127.0.0.1:8081")
+	if !strings.HasPrefix(got, DirectScheme+"://") {
+		t.Fatalf("unexpected scheme prefix: %q", got)
+	}
+	if !strings.Contains(got, "name=mysvc") {
+		t.Fatalf("missing name param: %q", got)
+	}
+	if !strings.Contains(got, "127.0.0.1:8080") || !strings.Contains(got, "127.0.0.1:8081") {
+		t.Fatalf("missing endpoints: %q", got)
+	}
+}
+
+func TestBuildDiscoveryTarget(t *testing.T) {
+	t.Parallel()
+
+	got := BuildDiscoveryTarget("test-service")
+	want := DiscoveryScheme + "://test-service"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestGetServiceUniqueId(t *testing.T) {
+	t.Parallel()
+
+	if got := getServiceUniqueId("svc", 3); got != "svc-3" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestNewAddr(t *testing.T) {
+	t.Parallel()
+
+	addr := newAddr("10.0.0.1:443", "api.example.com")
+	if addr.Addr != "10.0.0.1:443" || addr.ServerName != "api.example.com" {
+		t.Fatalf("addr=%+v", addr)
+	}
+}

--- a/clients/grpcc/middleware_test.go
+++ b/clients/grpcc/middleware_test.go
@@ -1,0 +1,153 @@
+package grpcc
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/pubgo/lava/v2/clients/grpcc/grpccconfig"
+	"github.com/pubgo/lava/v2/lava"
+	"github.com/pubgo/lava/v2/pkg/httputil"
+	"github.com/pubgo/lava/v2/pkg/lavacontexts"
+)
+
+func TestServiceFromMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method string
+		want   string
+	}{
+		{"", ""},
+		{"no-leading-slash", "no-leading-slash"},
+		{"/pkg.Service/Method", "pkg"},
+		{"/a.b.c.Service/Method", "a.b.c"},
+		{"/short", "/short"},
+	}
+	for _, tt := range tests {
+		if got := serviceFromMethod(tt.method); got != tt.want {
+			t.Errorf("serviceFromMethod(%q) = %q, want %q", tt.method, got, tt.want)
+		}
+	}
+}
+
+func TestUnaryInterceptorPreservesRequestID(t *testing.T) {
+	t.Parallel()
+
+	const wantID = "req-from-ctx"
+	var gotID string
+	capture := lava.MiddlewareWrap{
+		Name: "capture",
+		Next: func(next lava.HandlerFunc) lava.HandlerFunc {
+			return func(ctx context.Context, req lava.Request) (lava.Response, error) {
+				gotID = string(req.Header().Peek(httputil.HeaderXRequestID))
+				return next(ctx, req)
+			}
+		},
+	}
+
+	ic := unaryInterceptor([]lava.Middleware{capture})
+	ctx := lavacontexts.CreateCtxWithReqID(context.Background(), wantID)
+	err := ic(
+		ctx,
+		"/demo.DemoService/Call",
+		struct{}{},
+		struct{}{},
+		nil,
+		func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	if gotID != wantID {
+		t.Fatalf("request id = %q, want %q", gotID, wantID)
+	}
+}
+
+func TestUnaryInterceptorContentTypeFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	var gotCT string
+	capture := lava.MiddlewareWrap{
+		Name: "capture",
+		Next: func(next lava.HandlerFunc) lava.HandlerFunc {
+			return func(ctx context.Context, req lava.Request) (lava.Response, error) {
+				gotCT = req.ContentType()
+				return next(ctx, req)
+			}
+		},
+	}
+
+	ic := unaryInterceptor([]lava.Middleware{capture})
+	md := metadata.Pairs("x-content-type", "application/json")
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	err := ic(
+		ctx,
+		"/demo.DemoService/Call",
+		struct{}{},
+		struct{}{},
+		nil,
+		func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	if gotCT != "application/json" {
+		t.Fatalf("content type = %q, want application/json", gotCT)
+	}
+}
+
+func TestUnaryInterceptorDefaultContentType(t *testing.T) {
+	t.Parallel()
+
+	var gotCT string
+	capture := lava.MiddlewareWrap{
+		Name: "capture",
+		Next: func(next lava.HandlerFunc) lava.HandlerFunc {
+			return func(ctx context.Context, req lava.Request) (lava.Response, error) {
+				gotCT = req.ContentType()
+				return next(ctx, req)
+			}
+		},
+	}
+
+	ic := unaryInterceptor([]lava.Middleware{capture})
+	err := ic(
+		context.Background(),
+		"/demo.DemoService/Call",
+		struct{}{},
+		struct{}{},
+		nil,
+		func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	if gotCT != grpccconfig.DefaultContentType {
+		t.Fatalf("content type = %q, want default %q", gotCT, grpccconfig.DefaultContentType)
+	}
+}
+
+func TestHead2MdRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	header := httputil.NewRequestHeader()
+	header.Set("X-Custom", "value")
+	md := metadata.MD{}
+	head2md(header, md)
+
+	out := httputil.NewRequestHeader()
+	md2Head(md, out)
+
+	if string(out.Peek("X-Custom")) != "value" {
+		t.Fatalf("got %q", out.Peek("X-Custom"))
+	}
+}

--- a/pkg/middleware/accesslog/middleware_test.go
+++ b/pkg/middleware/accesslog/middleware_test.go
@@ -1,0 +1,67 @@
+package accesslog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pubgo/funk/v2/log"
+
+	"github.com/pubgo/lava/v2/lava"
+	"github.com/pubgo/lava/v2/pkg/httputil"
+	"github.com/pubgo/lava/v2/pkg/middleware/accesslog"
+)
+
+type stubRequest struct {
+	header lava.RequestHeader
+	client bool
+}
+
+func (s stubRequest) Kind() string               { return "grpc" }
+func (s stubRequest) Client() bool               { return s.client }
+func (s stubRequest) Header() lava.RequestHeader { return s.header }
+func (s stubRequest) Payload() any               { return nil }
+func (s stubRequest) ContentType() string        { return "application/grpc" }
+func (s stubRequest) Service() string            { return "demo" }
+func (s stubRequest) Operation() string          { return "/demo.Demo/Call" }
+func (s stubRequest) Endpoint() string           { return "/demo.Demo/Call" }
+func (s stubRequest) Stream() bool               { return false }
+
+type stubResponse struct {
+	header lava.ResponseHeader
+}
+
+func (s stubResponse) Header() lava.ResponseHeader { return s.header }
+func (s stubResponse) Payload() any                { return nil }
+func (s stubResponse) Stream() bool                { return false }
+
+func TestAccessLogSetsLatencyHeaderOnServer(t *testing.T) {
+	t.Parallel()
+
+	mw := accesslog.New(log.GetLogger("test"))
+	rspHeader := httputil.NewResponseHeader()
+	handler := mw.Middleware(func(ctx context.Context, req lava.Request) (lava.Response, error) {
+		return stubResponse{header: rspHeader}, nil
+	})
+
+	req := stubRequest{header: httputil.NewRequestHeader(), client: false}
+	if _, err := handler(context.Background(), req); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if len(rspHeader.Peek("X-Request-Latency")) == 0 {
+		t.Fatal("expected X-Request-Latency response header")
+	}
+}
+
+func TestAccessLogPassesThroughSuccess(t *testing.T) {
+	t.Parallel()
+
+	mw := accesslog.New(log.GetLogger("test"))
+	handler := mw.Middleware(func(ctx context.Context, req lava.Request) (lava.Response, error) {
+		return stubResponse{header: httputil.NewResponseHeader()}, nil
+	})
+
+	req := stubRequest{header: httputil.NewRequestHeader(), client: true}
+	if _, err := handler(context.Background(), req); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+}

--- a/pkg/middleware/metric/middleware_test.go
+++ b/pkg/middleware/metric/middleware_test.go
@@ -1,0 +1,99 @@
+package metric_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	tally "github.com/uber-go/tally/v4"
+
+	"github.com/pubgo/lava/v2/lava"
+	"github.com/pubgo/lava/v2/pkg/httputil"
+	"github.com/pubgo/lava/v2/pkg/middleware/metric"
+)
+
+type stubRequest struct {
+	kind      string
+	operation string
+}
+
+func (s stubRequest) Kind() string               { return s.kind }
+func (s stubRequest) Client() bool               { return false }
+func (s stubRequest) Header() lava.RequestHeader { return httputil.NewRequestHeader() }
+func (s stubRequest) Payload() any               { return nil }
+func (s stubRequest) ContentType() string        { return "" }
+func (s stubRequest) Service() string            { return "demo" }
+func (s stubRequest) Operation() string          { return s.operation }
+func (s stubRequest) Endpoint() string           { return s.operation }
+func (s stubRequest) Stream() bool               { return false }
+
+type stubResponse struct{}
+
+func (stubResponse) Header() lava.ResponseHeader { return httputil.NewResponseHeader() }
+func (stubResponse) Payload() any                { return nil }
+func (stubResponse) Stream() bool                { return false }
+
+func counterValue(snap tally.Snapshot, name string) int64 {
+	for key, c := range snap.Counters() {
+		if strings.Contains(key, name) {
+			return c.Value()
+		}
+	}
+	return 0
+}
+
+func TestMetricMiddlewareSkipsHTTP(t *testing.T) {
+	t.Parallel()
+
+	scope := tally.NewTestScope("test", nil)
+	mw := metric.New(scope)
+	handler := mw.Middleware(func(ctx context.Context, req lava.Request) (lava.Response, error) {
+		return stubResponse{}, nil
+	})
+
+	if _, err := handler(context.Background(), stubRequest{kind: "http", operation: "GET /"}); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if len(scope.Snapshot().Counters()) != 0 {
+		t.Fatalf("expected no counters for http request, got %+v", scope.Snapshot().Counters())
+	}
+}
+
+func TestMetricMiddlewareRecordsGRPCCall(t *testing.T) {
+	t.Parallel()
+
+	scope := tally.NewTestScope("test", nil)
+	mw := metric.New(scope)
+	handler := mw.Middleware(func(ctx context.Context, req lava.Request) (lava.Response, error) {
+		return stubResponse{}, nil
+	})
+
+	const op = "/demo.Demo/Call"
+	if _, err := handler(context.Background(), stubRequest{kind: "grpc", operation: op}); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	if counterValue(scope.Snapshot(), "grpc_server_rpc_total") != 1 {
+		t.Fatalf("rpc total counter missing, counters=%+v", scope.Snapshot().Counters())
+	}
+}
+
+func TestMetricMiddlewareRecordsError(t *testing.T) {
+	t.Parallel()
+
+	scope := tally.NewTestScope("test", nil)
+	mw := metric.New(scope)
+	handler := mw.Middleware(func(ctx context.Context, req lava.Request) (lava.Response, error) {
+		return nil, errors.New("fail")
+	})
+
+	const op = "/demo.Demo/Call"
+	if _, err := handler(context.Background(), stubRequest{kind: "grpc", operation: op}); err == nil {
+		t.Fatal("expected error")
+	}
+
+	if counterValue(scope.Snapshot(), "grpc_server_rpc_failed_total") != 1 {
+		t.Fatalf("failed counter missing, counters=%+v", scope.Snapshot().Counters())
+	}
+}

--- a/pkg/middleware/serviceinfo/middleware_test.go
+++ b/pkg/middleware/serviceinfo/middleware_test.go
@@ -1,0 +1,96 @@
+package serviceinfo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pubgo/lava/v2/lava"
+	"github.com/pubgo/lava/v2/pkg/grpcutil"
+	"github.com/pubgo/lava/v2/pkg/httputil"
+	"github.com/pubgo/lava/v2/pkg/lavacontexts"
+	"github.com/pubgo/lava/v2/pkg/middleware/serviceinfo"
+)
+
+type stubRequest struct {
+	header lava.RequestHeader
+	client bool
+}
+
+func (s stubRequest) Kind() string               { return "grpc" }
+func (s stubRequest) Client() bool               { return s.client }
+func (s stubRequest) Header() lava.RequestHeader { return s.header }
+func (s stubRequest) Payload() any               { return nil }
+func (s stubRequest) ContentType() string        { return "" }
+func (s stubRequest) Service() string            { return "demo" }
+func (s stubRequest) Operation() string          { return "/demo.Demo/Call" }
+func (s stubRequest) Endpoint() string           { return "/demo.Demo/Call" }
+func (s stubRequest) Stream() bool               { return false }
+
+type stubResponse struct {
+	header lava.ResponseHeader
+}
+
+func (s stubResponse) Header() lava.ResponseHeader { return s.header }
+func (s stubResponse) Payload() any                { return nil }
+func (s stubResponse) Stream() bool                { return false }
+
+func TestServiceInfoClientPopulatesServerContext(t *testing.T) {
+	t.Parallel()
+
+	mw := serviceinfo.New()
+	handler := mw.Middleware(func(ctx context.Context, req lava.Request) (lava.Response, error) {
+		info := lavacontexts.GetServerInfo(ctx)
+		if info == nil || info.GetPath() != "/demo.Demo/Call" {
+			t.Fatalf("server info = %+v", info)
+		}
+		return stubResponse{header: httputil.NewResponseHeader()}, nil
+	})
+
+	req := stubRequest{header: httputil.NewRequestHeader(), client: true}
+	if _, err := handler(context.Background(), req); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+}
+
+func TestServiceInfoServerReadsClientInfoFromHeaders(t *testing.T) {
+	t.Parallel()
+
+	mw := serviceinfo.New()
+	header := httputil.NewRequestHeader()
+	header.Set(grpcutil.ClientNameKey, "remote-svc")
+	header.Set(grpcutil.ClientPathKey, "/remote.Op")
+
+	handler := mw.Middleware(func(ctx context.Context, req lava.Request) (lava.Response, error) {
+		info := lavacontexts.GetClientInfo(ctx)
+		if info == nil || info.GetName() != "remote-svc" || info.GetPath() != "/remote.Op" {
+			t.Fatalf("client info = %+v", info)
+		}
+		return stubResponse{header: httputil.NewResponseHeader()}, nil
+	})
+
+	req := stubRequest{header: header, client: false}
+	if _, err := handler(context.Background(), req); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+}
+
+func TestServiceInfoSetsResponseRequestID(t *testing.T) {
+	t.Parallel()
+
+	const wantID = "fixed-req-id"
+	ctx := lavacontexts.CreateCtxWithReqID(context.Background(), wantID)
+
+	mw := serviceinfo.New()
+	rspHeader := httputil.NewResponseHeader()
+	handler := mw.Middleware(func(ctx context.Context, req lava.Request) (lava.Response, error) {
+		return stubResponse{header: rspHeader}, nil
+	})
+
+	req := stubRequest{header: httputil.NewRequestHeader(), client: false}
+	if _, err := handler(ctx, req); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if got := string(rspHeader.Peek(httputil.HeaderXRequestID)); got != wantID {
+		t.Fatalf("response request id = %q, want %q", got, wantID)
+	}
+}

--- a/pkg/wsproxy/websocket_proxy_test.go
+++ b/pkg/wsproxy/websocket_proxy_test.go
@@ -1,0 +1,99 @@
+package wsproxy
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsClosedConnError(t *testing.T) {
+	t.Parallel()
+
+	if !isClosedConnError(errors.New("use of closed network connection")) {
+		t.Fatal("expected closed network connection to match")
+	}
+	if isClosedConnError(errors.New("other error")) {
+		t.Fatal("unexpected match")
+	}
+}
+
+func TestWebsocketProxyPassesNonUpgradeRequests(t *testing.T) {
+	t.Parallel()
+
+	const body = "plain-http"
+	handler := WebsocketProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte(body))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusTeapot)
+	}
+	if got := rec.Body.String(); got != body {
+		t.Fatalf("body = %q, want %q", got, body)
+	}
+}
+
+func TestWebsocketProxyReadLimitDefaults(t *testing.T) {
+	t.Parallel()
+
+	h := WebsocketProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	p := h.(*Proxy)
+	if p.ReadLimit != maxMessageSize {
+		t.Fatalf("ReadLimit = %d, want %d", p.ReadLimit, maxMessageSize)
+	}
+}
+
+func TestWebsocketProxyWithReadLimit(t *testing.T) {
+	t.Parallel()
+
+	const limit = 128 * 1024
+	h := WebsocketProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), WithReadLimit(limit))
+	p := h.(*Proxy)
+	if p.ReadLimit != limit {
+		t.Fatalf("ReadLimit = %d, want %d", p.ReadLimit, limit)
+	}
+}
+
+func TestInMemoryResponseWriter(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	w := newInMemoryResponseWriter(&buf)
+	w.Header().Set("X-Test", "1")
+	w.WriteHeader(http.StatusCreated)
+
+	n, err := w.Write([]byte("line\n"))
+	if err != nil || n != 5 {
+		t.Fatalf("Write: n=%d err=%v", n, err)
+	}
+	if w.Header().Get("X-Test") != "1" {
+		t.Fatal("header not preserved")
+	}
+	if w.code != http.StatusCreated {
+		t.Fatalf("code = %d", w.code)
+	}
+	if buf.String() != "line\n" {
+		t.Fatalf("buffer = %q", buf.String())
+	}
+}
+
+func TestWebsocketProxyWithOptions(t *testing.T) {
+	t.Parallel()
+
+	h := WebsocketProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+		WithMethodParamOverride("verb"),
+		WithTokenCookieName("auth"),
+		WithPingPong(true),
+	)
+	p := h.(*Proxy)
+	if p.methodOverrideParam != "verb" || p.tokenCookieName != "auth" || !p.enablePingPong {
+		t.Fatalf("options not applied: %+v", p)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `clients/grpcc/middleware_test.go` for `serviceFromMethod`, metadata/content-type handling, and request ID propagation.
- Add `clients/grpcc/grpccresolver/util_test.go` for target builders and address helpers.
- Add `pkg/wsproxy/websocket_proxy_test.go` for non-WebSocket pass-through, options, and response writer helpers.
- Add tests for `pkg/middleware/accesslog`, `serviceinfo`, and `metric` (recovery already covered).

Partially addresses #112 (curlcmd still untested).

## Test plan
- [x] `go test ./clients/grpcc/... ./pkg/wsproxy/... ./pkg/middleware/... -race -short`
- [x] `go test ./... -race -short`
- [x] `golangci-lint run ./clients/grpcc/... ./pkg/wsproxy/... ./pkg/middleware/...`


Made with [Cursor](https://cursor.com)