### PR TITLE
docs: unify gateway_server wording after grpcs removal

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ These instructions are project-wide defaults for this repository. Keep changes f
 
 ## Architecture
 
-- `lava/`: core public interfaces and contracts (`Middleware`, routers, request/response abstractions).
+- `pkg/lava/`: core public interfaces and contracts (`Middleware`, routers, request/response abstractions). Root `lava/` is a deprecated type-alias shim.
 - `core/`: runtime capabilities (supervisor, scheduler, tunnel, logging/metrics/tracing, debug, DI builder).
 - `servers/`: service hosts (`gatewayserver` multi-protocol gateway, `https` on Fiber, `zrpcs` on NATS).
 - `clients/`: outbound client implementations (`grpcc`, `resty`).
@@ -14,7 +14,7 @@ These instructions are project-wide defaults for this repository. Keep changes f
 - `internal/`: repository-internal implementation details/examples; avoid exposing as public API.
 
 Place new code by responsibility:
-- Cross-protocol abstractions -> `lava/`
+- Cross-protocol abstractions -> `pkg/lava/`（根 `lava/` 仅为 deprecated shim）
 - Runtime framework capability -> `core/<module>/`
 - HTTP/gRPC serving behavior -> `servers/`
 - Reusable public helper/component -> `pkg/`

--- a/deploy/traefik/README.md
+++ b/deploy/traefik/README.md
@@ -18,9 +18,9 @@ lava gateway 是多协议网关，三类入站协议在 L7 上性质不同，**�
 
 | 协议 | 默认端口 | 配置项 | 回源 scheme | 备注 |
 | --- | --- | --- | --- | --- |
-| HTTP/REST + gRPC-Web | 8080 | `grpc_server.http_port` | `http` | REST 挂在 `/api` 前缀；gRPC-Web 是普通 POST |
-| WebSocket | 8081 | `grpc_server.websocket_port` | `http` | HTTP/1.1 `Upgrade`，Traefik 自动透传 |
-| 原生 gRPC | 50051 | `grpc_server.grpc_port` | **`h2c`** | 明文 HTTP/2，必须用 h2c |
+| HTTP/REST + gRPC-Web | 8080 | `gateway_server.http` / `running.HttpPort` | `http` | REST 挂在 `/api` 前缀；gRPC-Web 是普通 POST |
+| WebSocket | 8081 | `gateway_server.websocket_port` | `http` | HTTP/1.1 `Upgrade`，Traefik 自动透传 |
+| 原生 gRPC | 50051 | `gateway_server.grpc` / `running.GrpcPort` | **`h2c`** | 明文 HTTP/2，必须用 h2c |
 
 > 关键点：原生 gRPC 回源**必须**用 `h2c://`（明文 HTTP/2）。若写成 `http://`，
 > Traefik 会按 HTTP/1.1 回源，gRPC 直接失败。
@@ -82,6 +82,6 @@ gRPC streaming 与 WebSocket 是长连接，`traefik.yml` 中 `idleConnTimeout` 
 
 - 关闭或鉴权保护 Traefik dashboard（`api.dashboard`）。
 - `acme.json` 含真实证书后勿提交到 git（本地/服务器持久化即可）。
-- WebSocket 务必在 `grpc_server.websocket_origin_patterns` 配置允许的来源，
+- WebSocket 务必在 `gateway_server.websocket_origin_patterns` 配置允许的来源，
   不要依赖开发期默认的「跳过校验」。
 - `acme.json` 权限 `600`，并纳入持久化卷。

--- a/deploy/traefik/docker-compose.yml
+++ b/deploy/traefik/docker-compose.yml
@@ -27,9 +27,9 @@ services:
 
   # 你的 lava gateway 服务。这里用占位镜像示意端口映射关系，
   # 实际换成自己构建的镜像，并确保监听以下端口：
-  #   8080  = grpc_server.http_port（REST 挂在 /api 前缀 + gRPC-Web）
-  #   8081  = grpc_server.websocket_port
-  #   50051 = grpc_server.grpc_port（原生 gRPC，明文 h2c）
+  #   8080  = gateway_server.http（REST 挂在 /api 前缀 + gRPC-Web）
+  #   8081  = gateway_server.websocket_port
+  #   50051 = gateway_server.grpc（原生 gRPC，明文 h2c）
   gateway:
     image: your-org/lava-gateway:latest
     expose:

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -94,9 +94,9 @@ flowchart TD
 ```
 
 - **命令**：`lava grpc` → `gatewayserver.New`（`cmds/grpcservercmd`）
-- **配置**：`gateway_server`（推荐）或 legacy `grpc_server`
+- **配置**：`gateway_server`（`gatewayserver.LoadConfig`）
 - **TLS**：框架内不处理；Traefik 边缘终止，回源 `http` / `h2c`
-- **调试**：`/debug/vars` 暴露 `gateway-server-info`（兼容 `grpc-server-info`）
+- **调试**：`/debug/vars` 暴露 `gateway-server-info`（兼容旧名 `grpc-server-info`）
 
 ### 通路 B：NATS 微服务（zrpc）
 
@@ -111,7 +111,7 @@ zrpc Client → NATS (subject + queue) → zrpc.Server → 业务 Handler
 | `servers/zrpcs` | 纯 NATS 微服务宿主，代码生成 `Register...ZrpcRoutes` |
 | `pkg/zrpcbridge.RegisterMux` | 把已在 `gateway.Mux` 注册的 handler **额外**暴露到 NATS |
 
-> 重构后：zrpc **不是** gateway 前端，而是可选桥接。`grpc_server.zrpc_url` 已移除。
+> 重构后：zrpc **不是** gateway 前端，而是可选桥接。`gateway_server.zrpc_url`（旧 `grpc_server.zrpc_url`）已移除。
 
 ### 通路 C：反向隧道（tunnel）
 
@@ -360,7 +360,7 @@ lava/
 | --- | --- |
 | `servers/grpcs` 包 | 已删除；使用 `gatewayserver` |
 | `Mux.RegisterZrpc` | `pkg/zrpcbridge.RegisterMux`（DI 显式调用） |
-| `grpc_server.zrpc_url` 配置 | 已移除 |
+| `gateway_server.zrpc_url`（旧 `grpc_server.zrpc_url`） | 已移除 |
 | 原生 gRPC 空占位 `stream.grpc.go` | 已删除（直接用 `grpc.ServerStream`） |
 
 设计原则：

--- a/docs/design-v2.md
+++ b/docs/design-v2.md
@@ -16,7 +16,7 @@ Lava 在设计上聚焦三件事：
 
 ## 2. 核心抽象
 
-### 2.1 中间件抽象（`lava/middleware.go`）
+### 2.1 中间件抽象（`pkg/lava/middleware.go`）
 
 ```go
 type HandlerFunc func(ctx context.Context, req Request) (Response, error)
@@ -29,7 +29,7 @@ type Middleware interface {
 
 这是一种“函数包裹函数”的链式模型，支持同一语义在 HTTP/gRPC/Client 场景复用。
 
-### 2.2 路由抽象（`lava/router.go`）
+### 2.2 路由抽象（`pkg/lava/router.go`）
 
 ```go
 type HttpRouter interface {
@@ -60,7 +60,7 @@ type Service interface {
 
 `supervisor.Manager` 基于该接口实现生命周期托管、重启策略和状态观测。
 
-### 2.4 统一请求抽象（`lava/request.go` / `lava/response.go`）
+### 2.4 统一请求抽象（`pkg/lava/request.go` / `pkg/lava/response.go`）
 
 当前 `lava.RequestKind` 已覆盖：
 
@@ -165,5 +165,5 @@ stateDiagram-v2
 ## 7. 文档与实现的一致性建议
 
 1. 命令文档以 `main.go` 作为根入口真值。
-2. 接口文档优先引用 `lava/*.go` 与 `core/supervisor/types.go`。
+2. 接口文档优先引用 `pkg/lava/*.go` 与 `core/supervisor/types.go`。
 3. 流程图更新时，必须同步标注对应实现路径。

--- a/docs/modules/pkg.md
+++ b/docs/modules/pkg.md
@@ -70,4 +70,4 @@ zrpc Client → NATS → zrpc.Server → zrpcbridge → gateway.Mux → handler
 | `servers/zrpcs` | 纯 NATS 微服务宿主 |
 | `pkg/zrpcbridge` | 可选：把 Mux handler 额外暴露到 NATS |
 
-用法见 `pkg/zrpcbridge/README.md`；此前 `Mux.RegisterZrpc` 与 `grpc_server.zrpc_url` 已移除。
+用法见 `pkg/zrpcbridge/README.md`；此前 `Mux.RegisterZrpc` 与 `gateway_server.zrpc_url`（旧 `grpc_server.zrpc_url`）已移除。

--- a/pkg/gateway/docs/grpcnative.md
+++ b/pkg/gateway/docs/grpcnative.md
@@ -32,17 +32,17 @@ grpcServer := grpc.NewServer(grpc.UnknownServiceHandler(handler))
 
 **注意**：启用透传后，不要再对同一个 `grpc.Server` 调用 `RegisterService`，否则会与 `UnknownServiceHandler` 冲突。
 
-### grpc-server 配置
+### gateway_server 配置
 
 ```yaml
-grpc_server:
+gateway_server:
   grpc_passthrough: true
   websocket_port: 8081
 ```
 
 开启后，`servers/gatewayserver` 仅在 `Mux` 上注册服务，gRPC 端口上的原生客户端与 HTTP/WS 前端共享同一套 handler。
 
-> **默认值**：`grpc_passthrough` 默认为 `false`，保持与现有部署兼容（服务同时注册在 Mux 与外层 `grpc.Server`）。新部署若希望「RegisterService 一次、多协议复用」，建议显式设为 `true`。
+> **默认值**：`grpc_passthrough` 默认为 `true`（handler 仅在 Mux 注册）。若需 legacy 双注册（同时挂在外层 `grpc.Server`），显式设为 `false`。
 
 ## 与其他前端的关系
 

--- a/pkg/gateway/docs/grpcnats.md
+++ b/pkg/gateway/docs/grpcnats.md
@@ -13,4 +13,4 @@ import "github.com/pubgo/lava/v2/pkg/zrpcbridge"
 _ = zrpcbridge.RegisterMux(zrpcSrv, mux, zrpcbridge.Config{Queue: "my-service"})
 ```
 
-原先 `grpc_server.zrpc_url` 配置项已移除；请在应用 DI 中显式连接 NATS 并调用 `RegisterMux`。
+原先 `gateway_server.zrpc_url`（旧 `grpc_server.zrpc_url`）配置项已移除；请在应用 DI 中显式连接 NATS 并调用 `RegisterMux`。

--- a/pkg/gateway/docs/websocket.md
+++ b/pkg/gateway/docs/websocket.md
@@ -130,12 +130,12 @@ HTTP 握手请求头会被转换为 gRPC 的 incoming metadata，供服务端通
 - 通过 REST 注解路径访问时，`streamWS` 会带上匹配到的 `MatchOperation`，因此 `body:"field"` / `response_body` 字段映射对 WebSocket 同样生效；直查 gRPC 全方法名时整条消息即请求/响应体。
 - 结束时通过 WebSocket Close 帧回传结构化 gRPC 状态：close code 由 gRPC code 映射，reason 为 JSON `{"grpcStatus":N,"grpcMessage":"..."}`，客户端可解析 `event.reason` 获取状态。
 
-## 在 grpc-server 中启用
+## 在 gateway 中启用
 
-在 `grpc_server` 配置里设置 `websocket_port` 即可在独立端口启动 WebSocket 前端（与 Fiber HTTP 端口分离）：
+在 `gateway_server` 配置里设置 `websocket_port` 即可在独立端口启动 WebSocket 前端（与 Fiber HTTP 端口分离）：
 
 ```yaml
-grpc_server:
+gateway_server:
   websocket_port: 8081
   # 生产环境建议配置 Origin 白名单
   websocket_origin_patterns:
@@ -168,7 +168,7 @@ mux.WebSocketHandler(gateway.WSOptionsFromConfig(gateway.WSConfig{
 生产环境务必配置 `websocket_origin_patterns`，例如：
 
 ```yaml
-grpc_server:
+gateway_server:
   websocket_port: 8081
   websocket_origin_patterns:
     - "example.com"


### PR DESCRIPTION
## Summary
- 在主文档统一使用 `gatewayserver` + `gateway_server` 表述
- 更新 Traefik 与 `pkg/gateway/docs` 示例，统一配置键命名
- 文档保留 legacy 说明，但不再把 `servers/grpcs` 当作仍存在的可用包

## Test plan
- [x] 文档改动，仅做 diff 审阅

## Notes
- 此 PR 是 #150 的后继（rebase 到最新 `v2` 并适配 #151 已删除 `servers/grpcs`）

Made with [Cursor](https://cursor.com)