### PR TITLE
chore: split legacy config coverage into test:legacy

### DIFF
--- a/docs/legacy-removal.md
+++ b/docs/legacy-removal.md
@@ -72,5 +72,5 @@ gateway_server:
 - [x] `internal/configs/components/grpc_server.yaml` 已移除，统一 `gateway_server.yaml`
 - [x] `lavabuilder grpc` 通过 `gatewayserver.LoadConfig` 加载 YAML 并对 `grpc_server` 打废弃警告
 - [x] 架构文档仅描述 `gateway_server`
-- [ ] `task test` 不依赖 legacy 路径（或单独 `task test:legacy`）
+- [x] `task test` 不依赖 legacy 路径；兼容用例移至 `task test:legacy`
 - [x] 删除 `grpcs` 包（v2，不再等待 v3）

--- a/servers/gatewayserver/config_legacy_test.go
+++ b/servers/gatewayserver/config_legacy_test.go
@@ -1,0 +1,21 @@
+//go:build legacy
+// +build legacy
+
+package gatewayserver
+
+import (
+	"testing"
+
+	"github.com/pubgo/funk/v2/log"
+)
+
+func TestResolveConfigLegacyGrpcServer(t *testing.T) {
+	t.Parallel()
+
+	cfg := ResolveConfig(CombinedConfigLoader{
+		GrpcServer: &Config{EnablePrintRouter: true},
+	}, log.GetLogger("test"))
+	if !cfg.EnablePrintRouter {
+		t.Fatal("expected legacy grpc_server config to apply")
+	}
+}

--- a/servers/gatewayserver/config_test.go
+++ b/servers/gatewayserver/config_test.go
@@ -2,8 +2,6 @@ package gatewayserver
 
 import (
 	"testing"
-
-	"github.com/pubgo/funk/v2/log"
 )
 
 func TestResolveConfigPrefersGatewayServer(t *testing.T) {
@@ -15,17 +13,6 @@ func TestResolveConfigPrefersGatewayServer(t *testing.T) {
 	}, nil)
 	if !cfg.EnablePrintRouter {
 		t.Fatal("expected gateway_server to win")
-	}
-}
-
-func TestResolveConfigLegacyGrpcServer(t *testing.T) {
-	t.Parallel()
-
-	cfg := ResolveConfig(CombinedConfigLoader{
-		GrpcServer: &Config{EnablePrintRouter: true},
-	}, log.GetLogger("test"))
-	if !cfg.EnablePrintRouter {
-		t.Fatal("expected legacy grpc_server config to apply")
 	}
 }
 

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -66,8 +66,13 @@ tasks:
     cmds:
       - go vet ./...
   test:
+    desc: "run default test suite (without legacy-tagged compatibility tests)"
     cmds:
       - go test -short -race -v ./... -cover
+  test:legacy:
+    desc: "run legacy compatibility tests"
+    cmds:
+      - go test -short -race -v -tags legacy ./servers/gatewayserver -run TestResolveConfigLegacyGrpcServer
   lint:
     cmds:
       - golangci-lint run --verbose ./...


### PR DESCRIPTION
## Summary
- 将 `TestResolveConfigLegacyGrpcServer` 移到 `legacy` build tag 文件
- 新增 `task test:legacy`（专门验证 `grpc_server` 兼容逻辑）
- 保持 `task test` 为默认主路径测试，不依赖 legacy 路径
- 更新 `docs/legacy-removal.md` 清单并勾选对应项

## Test plan
- [x] `go test -short -race ./...`
- [x] `task test:legacy`


Made with [Cursor](https://cursor.com)