### PR TITLE
refactor: remove HasLocalIPddr alias before v2 release

### DIFF
--- a/docs/legacy-removal.md
+++ b/docs/legacy-removal.md
@@ -45,7 +45,7 @@
 
 | 项 | 位置 | 替代 |
 |----|------|------|
-| `IsLocalIPAdd`（拼写错误） | `pkg/netutil/ip.go` | `IsLocalIPAddr`（保留旧名至 v3 前） |
+| `HasLocalIPddr`（拼写错误） | `pkg/netutil/ip.go` | `HasLocalIPAddr` |
 
 ## 配置迁移示例
 

--- a/pkg/netutil/ip.go
+++ b/pkg/netutil/ip.go
@@ -9,12 +9,6 @@ import (
 	"strings"
 )
 
-// HasLocalIPddr 检测 IP 地址字符串是否是内网地址
-// Deprecated: 此为一个错误名称错误拼写的函数，计划在将来移除，请使用 HasLocalIPAddr 函数
-func HasLocalIPddr(ip string) bool {
-	return HasLocalIPAddr(ip)
-}
-
 // HasLocalIPAddr 检测 IP 地址字符串是否是内网地址
 func HasLocalIPAddr(ip string) bool {
 	return HasLocalIP(net.ParseIP(ip))


### PR DESCRIPTION
## Summary
- 删除 `pkg/netutil.HasLocalIPddr`（历史拼写错误别名）
- 统一保留 `HasLocalIPAddr` 作为公网 API
- 更新 `docs/legacy-removal.md` 的 API 项说明

## Test plan
- [x] `go test -short -race ./...`


Made with [Cursor](https://cursor.com)