### PR TITLE
refactor: remove grpc_server YAML key compatibility

### DIFF
--- a/docs/legacy-removal.md
+++ b/docs/legacy-removal.md
@@ -32,25 +32,25 @@
 |----|----------|
 | `servers/grpcs` 包 | `servers/gatewayserver` + `grpc_passthrough: true` |
 
-### 配置键
+### 配置键（已移除）
 
-| Legacy 键 | 替代键 |
+| 已删除键 | 替代键 |
 |-----------|--------|
 | `grpc_server` | `gateway_server` |
 | `grpc_server.yaml` 组件 | `gateway_server.yaml` |
 
-迁移：将 YAML 顶层键 `grpc_server` 重命名为 `gateway_server`；`ResolveConfig` 仍解析旧键并在启动时打 `Warn`（`lavabuilder grpc` 经 `gatewayserver.LoadConfig`）。
+迁移：YAML 顶层键统一为 `gateway_server`；`gatewayserver.LoadConfig` 不再解析 `grpc_server`。
 
 ### API
 
 | 项 | 位置 | 替代 |
 |----|------|------|
-| `IsLocalIPAdd`（拼写错误） | `pkg/netutil/ip.go` | `IsLocalIPAddr`（保留旧名至 v3 前） |
+| `HasLocalIPddr`（拼写错误） | `pkg/netutil/ip.go` | `HasLocalIPAddr` |
 
 ## 配置迁移示例
 
 ```yaml
-# 旧 (deprecated)
+# 旧 (removed)
 grpc_server:
   enable_print_router: true
 
@@ -70,7 +70,7 @@ gateway_server:
 - [x] 新示例不再引用 `servers/grpcs`
 - [x] HTTP 中间件链统一到 `servers/serverhttp.HandlerMiddleware`（#107）
 - [x] `internal/configs/components/grpc_server.yaml` 已移除，统一 `gateway_server.yaml`
-- [x] `lavabuilder grpc` 通过 `gatewayserver.LoadConfig` 加载 YAML 并对 `grpc_server` 打废弃警告
+- [x] `gatewayserver.LoadConfig` 仅加载 `gateway_server`（不再解析 `grpc_server`）
 - [x] 架构文档仅描述 `gateway_server`
 - [ ] `task test` 不依赖 legacy 路径（或单独 `task test:legacy`）
 - [x] 删除 `grpcs` 包（v2，不再等待 v3）

--- a/docs/modules/servers.md
+++ b/docs/modules/servers.md
@@ -35,8 +35,6 @@
 
 YAML 键：**`gateway_server`**（见 `internal/configs/components/gateway_server.yaml`）。
 
-旧键 `grpc_server` 仍可解析，启动时会打废弃警告；详见 `docs/legacy-removal.md`。
-
 ```yaml
 gateway_server:
   enable_print_router: true
@@ -114,7 +112,7 @@ flowchart LR
 
 | 项 | 替代 |
 | --- | --- |
-| YAML 键 `grpc_server` | `gateway_server` |
+| YAML 键 `grpc_server` | 已删除；请改为 `gateway_server` |
 | `grpc_passthrough: false` | 默认 `true` |
 | `servers/grpcs` 包 | 已在 v2 删除，请用 `servers/gatewayserver` |
 

--- a/internal/configs/components/gateway_server.yaml
+++ b/internal/configs/components/gateway_server.yaml
@@ -1,5 +1,5 @@
 # Gateway server settings (servers/gatewayserver).
-# Legacy YAML key grpc_server is still parsed with a deprecation warning; use gateway_server only.
+# Use gateway_server only; grpc_server key is no longer supported.
 gateway_server:
   enable_print_router: true
   # New deployments: register handlers on Mux only; native gRPC uses passthrough.

--- a/pkg/gateway/docs/deploy.md
+++ b/pkg/gateway/docs/deploy.md
@@ -14,7 +14,6 @@ Gateway **不内置 HTTPS/TLS**。框架内全程明文（`http` / `h2c`），TL
 | YAML 键 | 说明 |
 | --- | --- |
 | `gateway_server` | **推荐**，见 `internal/configs/components/gateway_server.yaml` |
-| `grpc_server` | Legacy 别名，与 `gateway_server` 字段相同 |
 
 新部署建议显式设置 `grpc_passthrough: true`，使 handler 仅在 `gateway.Mux` 注册一次，
 原生 gRPC 与 HTTP/WS 前端共享同一套实现。

--- a/servers/gatewayserver/config.go
+++ b/servers/gatewayserver/config.go
@@ -2,7 +2,6 @@ package gatewayserver
 
 import (
 	"github.com/pubgo/funk/v2/config"
-	"github.com/pubgo/funk/v2/log"
 	"github.com/pubgo/funk/v2/merge"
 
 	"github.com/pubgo/lava/v2/pkg/fiberbuilder"
@@ -18,44 +17,20 @@ type ConfigLoader struct {
 	GatewayServer *Config `yaml:"gateway_server"`
 }
 
-// GrpcServerConfigLoader is a legacy alias for grpc_server YAML key.
-type GrpcServerConfigLoader struct {
-	GrpcServer *Config `yaml:"grpc_server"`
-}
-
-// CombinedConfigLoader loads gateway_server and legacy grpc_server keys from YAML.
-type CombinedConfigLoader struct {
-	GatewayServer *Config `yaml:"gateway_server"`
-	GrpcServer    *Config `yaml:"grpc_server"`
-}
-
-// ResolveConfig merges YAML loaders, preferring gateway_server and warning on legacy grpc_server.
-func ResolveConfig(loader CombinedConfigLoader, logger log.Logger) *Config {
-	switch {
-	case loader.GatewayServer != nil && loader.GrpcServer != nil:
-		if logger != nil {
-			logger.Warn().Msg("both gateway_server and grpc_server are set; gateway_server wins — remove grpc_server from YAML")
-		}
+func ResolveConfig(loader ConfigLoader) *Config {
+	if loader.GatewayServer != nil {
 		return merge.Struct(defaultCfg(), loader.GatewayServer).Unwrap()
-	case loader.GatewayServer != nil:
-		return merge.Struct(defaultCfg(), loader.GatewayServer).Unwrap()
-	case loader.GrpcServer != nil:
-		if logger != nil {
-			logger.Warn().Msg("yaml key grpc_server is deprecated; rename to gateway_server (see docs/legacy-removal.md)")
-		}
-		return merge.Struct(defaultCfg(), loader.GrpcServer).Unwrap()
-	default:
-		return defaultCfg()
 	}
+	return defaultCfg()
 }
 
 // LoadConfig reads gateway settings from the active funk config path, if any.
-func LoadConfig(logger log.Logger) *Config {
+func LoadConfig() *Config {
 	if config.GetConfigPath() == "" {
 		return defaultCfg()
 	}
-	loaded := config.Load[CombinedConfigLoader]()
-	return ResolveConfig(loaded.T, logger)
+	loaded := config.Load[ConfigLoader]()
+	return ResolveConfig(loaded.T)
 }
 
 // Config holds HTTP/REST, WebSocket, and native gRPC gateway server settings.

--- a/servers/gatewayserver/config_test.go
+++ b/servers/gatewayserver/config_test.go
@@ -1,38 +1,22 @@
 package gatewayserver
 
-import (
-	"testing"
-
-	"github.com/pubgo/funk/v2/log"
-)
+import "testing"
 
 func TestResolveConfigPrefersGatewayServer(t *testing.T) {
 	t.Parallel()
 
-	cfg := ResolveConfig(CombinedConfigLoader{
+	cfg := ResolveConfig(ConfigLoader{
 		GatewayServer: &Config{EnablePrintRouter: true},
-		GrpcServer:    &Config{EnablePrintRouter: false},
-	}, nil)
+	})
 	if !cfg.EnablePrintRouter {
-		t.Fatal("expected gateway_server to win")
-	}
-}
-
-func TestResolveConfigLegacyGrpcServer(t *testing.T) {
-	t.Parallel()
-
-	cfg := ResolveConfig(CombinedConfigLoader{
-		GrpcServer: &Config{EnablePrintRouter: true},
-	}, log.GetLogger("test"))
-	if !cfg.EnablePrintRouter {
-		t.Fatal("expected legacy grpc_server config to apply")
+		t.Fatal("expected gateway_server config to apply")
 	}
 }
 
 func TestResolveConfigDefaults(t *testing.T) {
 	t.Parallel()
 
-	cfg := ResolveConfig(CombinedConfigLoader{}, nil)
+	cfg := ResolveConfig(ConfigLoader{})
 	if !cfg.GRPCPassthrough {
 		t.Fatal("expected default grpc_passthrough true")
 	}


### PR DESCRIPTION
## Summary
- 移除 `gatewayserver` 对 legacy `grpc_server` YAML 键的解析逻辑
- `LoadConfig` 仅加载 `gateway_server`（`ConfigLoader`）
- 同步更新配置文档与 legacy 清单说明

## Breaking change
- 使用 `grpc_server:` 的配置文件将不再生效；请改为 `gateway_server:`

## Test plan
- [x] `go test -short -race ./...`


Made with [Cursor](https://cursor.com)