### PR TITLE
refactor: remove pre-v2 legacy compatibility surfaces

### DIFF
--- a/docs/design-v2.md
+++ b/docs/design-v2.md
@@ -92,7 +92,7 @@ $$
 
 ### 3.2 Gateway 与 gRPC 服务同源注册
 
-`servers/gatewayserver` 装配 `pkg/gateway.Mux`，将同一套 `ServiceDesc` 暴露为 HTTP/REST、gRPC-Web、WebSocket 与原生 gRPC（可选 `grpc_passthrough`）。这使多种前端协议共享同一套 handler，减少重复维护。
+`servers/gatewayserver` 装配 `pkg/gateway.Mux`，将同一套 `ServiceDesc` 暴露为 HTTP/REST、gRPC-Web、WebSocket 与原生 gRPC 透传。这使多种前端协议共享同一套 handler，减少重复维护。
 
 NATS/zrpc 不属于 gateway 前端；若需把 Mux handler 额外暴露到 NATS，在 DI 中调用 `pkg/zrpcbridge.RegisterMux`。
 

--- a/docs/legacy-removal.md
+++ b/docs/legacy-removal.md
@@ -1,68 +1,56 @@
 # Legacy 代码移除计划
 
-本文档描述 Lava v2 中仍并行维护的 legacy 表面，以及建议的废弃与移除节奏。
+本文档描述 Lava v2 发版前已清理的 legacy 表面，以及仍保留的兼容项。
 
 ## 原则
 
-1. **v2.x**：保留兼容，启动时打印 `deprecation` 日志（如已支持）。
-2. **v2 末版**：文档与示例全部迁移到新 API，CI 对 legacy 路径仅做冒烟。
-3. **v3**：删除 legacy 包与配置键，不提供静默兼容。
+v2 尚未正式发布，发版前优先删除历史兼容层，避免首次发布即背负废弃 API。
 
-## 时间表（建议）
-
-| 阶段 | 版本/时间 | 动作 |
-|------|-----------|------|
-| 文档化 | 当前 | 本文件 + 各包 `Deprecated` 注释 |
-| 警告期 | v2.1+ | 使用 legacy 配置/包时 `log.Warn` |
-| 冻结 | v2.2+ | legacy 仅修安全 bug，不加功能 |
-| 移除 | v3.0 | 删除下表所列项 |
-
-## 待移除项
+## 已移除（v2 发版前）
 
 ### 服务与包
 
-| 项 | 位置 | 替代方案 |
-|----|------|----------|
-| `pkg/wsproxy` 废弃构造函数 | `pkg/wsproxy` | `pkg/gateway` WebSocket 前端 |
-| legacy gRPC 双注册 | `gatewayserver` `grpc_passthrough: false` | 默认 `true`，仅在 Mux 注册 |
-
-### 已移除（v2）
-
 | 项 | 替代方案 |
 |----|----------|
-| `servers/grpcs` 包 | `servers/gatewayserver` + `grpc_passthrough: true` |
+| `servers/grpcs` 包 | `servers/gatewayserver` |
+| legacy gRPC 双注册（`grpc_passthrough: false`） | 固定 Mux-only 注册 + 原生 gRPC 透传 |
+| `pkg/wsproxy` 包级 `MethodOverrideParam` / `TokenCookieName` | `WithMethodParamOverride` / `WithTokenCookieName` |
 
 ### 配置键
 
-| Legacy 键 | 替代键 |
+| 已删除键 | 替代键 |
 |-----------|--------|
 | `grpc_server` | `gateway_server` |
 | `grpc_server.yaml` 组件 | `gateway_server.yaml` |
-
-迁移：将 YAML 顶层键 `grpc_server` 重命名为 `gateway_server`；`ResolveConfig` 仍解析旧键并在启动时打 `Warn`（`lavabuilder grpc` 经 `gatewayserver.LoadConfig`）。
+| `grpc_passthrough` | 已内置，无需配置 |
 
 ### API
 
-| 项 | 位置 | 替代 |
-|----|------|------|
-| `IsLocalIPAdd`（拼写错误） | `pkg/netutil/ip.go` | `IsLocalIPAddr`（保留旧名至 v3 前） |
+| 项 | 替代 |
+|----|------|
+| `HasLocalIPddr`（拼写错误） | `HasLocalIPAddr` |
 
-## 配置迁移示例
+## 仍保留的兼容项
+
+| 项 | 说明 |
+|----|------|
+| 根目录 `lava/` 类型别名 shim | 指向 `pkg/lava`，发版后视情况移除 |
+| `grpc-server-info` debug vars 名 | 兼容 `lava curl` 与旧部署 |
+| metric 名 `grpc_server_rpc_*` | 观测指标名，非配置/API |
+
+## 配置示例
 
 ```yaml
-# 旧 (deprecated)
-grpc_server:
-  enable_print_router: true
-
-# 新
 gateway_server:
   enable_print_router: true
-  grpc_passthrough: true
+  websocket_port: 8081
+  http: {}
+  grpc: {}
 ```
 
 ## 相关 Issue
 
-- #87 / #120：grpc_passthrough 与双注册（已在 v2 默认 passthrough）
+- #87 / #120：grpc_passthrough 与双注册
 - #123：本计划
 
 ## 维护者检查清单
@@ -70,7 +58,9 @@ gateway_server:
 - [x] 新示例不再引用 `servers/grpcs`
 - [x] HTTP 中间件链统一到 `servers/serverhttp.HandlerMiddleware`（#107）
 - [x] `internal/configs/components/grpc_server.yaml` 已移除，统一 `gateway_server.yaml`
-- [x] `lavabuilder grpc` 通过 `gatewayserver.LoadConfig` 加载 YAML 并对 `grpc_server` 打废弃警告
+- [x] `gatewayserver.LoadConfig` 仅加载 `gateway_server`
 - [x] 架构文档仅描述 `gateway_server`
-- [ ] `task test` 不依赖 legacy 路径（或单独 `task test:legacy`）
-- [x] 删除 `grpcs` 包（v2，不再等待 v3）
+- [x] 删除 `grpcs` 包
+- [x] 删除 `grpc_server` YAML 键与 `grpc_passthrough: false` 双注册模式
+- [x] 删除 `pkg/wsproxy` 废弃包级变量
+- [x] 删除 `HasLocalIPddr` 拼写错误 API

--- a/docs/modules/servers.md
+++ b/docs/modules/servers.md
@@ -27,7 +27,7 @@
 1. 收集 `GrpcRouter` / `GrpcHttpRouter` → 注册到 `gateway.Mux`
 2. Fiber 挂 `/api` → `mux.Handler`
 3. 可选 `websocket_port` → 独立 `http.Server`
-4. gRPC：默认 `grpc_passthrough: true`（仅在 Mux 注册）；`false` 为 legacy 双注册
+4. gRPC：handler 仅在 `gateway.Mux` 注册，原生 gRPC 通过透传接入
 5. 全局中间件：serviceinfo / metric / accesslog / recovery
 6. `vars.Register` 路由信息（`gateway-server-info`，兼容 `grpc-server-info`）
 
@@ -35,12 +35,9 @@
 
 YAML 键：**`gateway_server`**（见 `internal/configs/components/gateway_server.yaml`）。
 
-旧键 `grpc_server` 仍可解析，启动时会打废弃警告；详见 `docs/legacy-removal.md`。
-
 ```yaml
 gateway_server:
   enable_print_router: true
-  grpc_passthrough: true
   websocket_port: 8081
   http: {}
   grpc: {}
@@ -110,12 +107,12 @@ flowchart LR
     Bridge -.-> NATS
 ```
 
-## Legacy（v3 移除）
+## 已移除兼容项
 
-| 项 | 替代 |
+| 项 | 说明 |
 | --- | --- |
-| YAML 键 `grpc_server` | `gateway_server` |
-| `grpc_passthrough: false` | 默认 `true` |
-| `servers/grpcs` 包 | 已在 v2 删除，请用 `servers/gatewayserver` |
+| YAML 键 `grpc_server` | 请使用 `gateway_server` |
+| `grpc_passthrough: false` | 双注册模式已删除 |
+| `servers/grpcs` 包 | 请使用 `servers/gatewayserver` |
 
 详见 `docs/legacy-removal.md`。

--- a/internal/configs/components/gateway_server.yaml
+++ b/internal/configs/components/gateway_server.yaml
@@ -1,9 +1,6 @@
 # Gateway server settings (servers/gatewayserver).
-# Legacy YAML key grpc_server is still parsed with a deprecation warning; use gateway_server only.
 gateway_server:
   enable_print_router: true
-  # New deployments: register handlers on Mux only; native gRPC uses passthrough.
-  grpc_passthrough: true
   # websocket_port: 8081
   # websocket_origin_patterns:
   #   - "https://*.example.com"

--- a/pkg/gateway/docs/deploy.md
+++ b/pkg/gateway/docs/deploy.md
@@ -13,11 +13,9 @@ Gateway **不内置 HTTPS/TLS**。框架内全程明文（`http` / `h2c`），TL
 
 | YAML 键 | 说明 |
 | --- | --- |
-| `gateway_server` | **推荐**，见 `internal/configs/components/gateway_server.yaml` |
-| `grpc_server` | Legacy 别名，与 `gateway_server` 字段相同 |
+| `gateway_server` | 见 `internal/configs/components/gateway_server.yaml` |
 
-新部署建议显式设置 `grpc_passthrough: true`，使 handler 仅在 `gateway.Mux` 注册一次，
-原生 gRPC 与 HTTP/WS 前端共享同一套实现。
+Handler 仅在 `gateway.Mux` 注册一次，原生 gRPC 与 HTTP/WS 前端共享同一套实现。
 
 ## 三类协议的回源规则
 

--- a/pkg/gateway/docs/grpcnative.md
+++ b/pkg/gateway/docs/grpcnative.md
@@ -36,13 +36,10 @@ grpcServer := grpc.NewServer(grpc.UnknownServiceHandler(handler))
 
 ```yaml
 gateway_server:
-  grpc_passthrough: true
   websocket_port: 8081
 ```
 
-开启后，`servers/gatewayserver` 仅在 `Mux` 上注册服务，gRPC 端口上的原生客户端与 HTTP/WS 前端共享同一套 handler。
-
-> **默认值**：`grpc_passthrough` 默认为 `true`（handler 仅在 Mux 注册）。若需 legacy 双注册（同时挂在外层 `grpc.Server`），显式设为 `false`。
+`servers/gatewayserver` 仅在 `Mux` 上注册服务，gRPC 端口上的原生客户端与 HTTP/WS 前端共享同一套 handler。
 
 ## 与其他前端的关系
 

--- a/pkg/netutil/ip.go
+++ b/pkg/netutil/ip.go
@@ -9,12 +9,6 @@ import (
 	"strings"
 )
 
-// HasLocalIPddr 检测 IP 地址字符串是否是内网地址
-// Deprecated: 此为一个错误名称错误拼写的函数，计划在将来移除，请使用 HasLocalIPAddr 函数
-func HasLocalIPddr(ip string) bool {
-	return HasLocalIPAddr(ip)
-}
-
 // HasLocalIPAddr 检测 IP 地址字符串是否是内网地址
 func HasLocalIPAddr(ip string) bool {
 	return HasLocalIP(net.ParseIP(ip))

--- a/pkg/wsproxy/websocket_proxy.go
+++ b/pkg/wsproxy/websocket_proxy.go
@@ -20,6 +20,9 @@ import (
 )
 
 const (
+	defaultMethodOverrideParam = "method"
+	defaultTokenCookieName     = "token"
+
 	// Time allowed to read write a message to the peer.
 	timeWait = 15 * time.Second
 
@@ -37,16 +40,6 @@ var (
 	pingPayload = []byte("ping")
 	pongPayload = []byte("pong")
 )
-
-// MethodOverrideParam defines the special URL parameter that is translated into the subsequent proxied streaming http request's method.
-//
-// Deprecated: it is preferable to use the Options parameters to WebSocketProxy to supply parameters.
-var MethodOverrideParam = "method"
-
-// TokenCookieName defines the cookie name that is translated to an 'Authorization: Bearer' header in the streaming http request's headers.
-//
-// Deprecated: it is preferable to use the Options parameters to WebSocketProxy to supply parameters.
-var TokenCookieName = "token"
 
 // RequestMutatorFunc can supply an alternate outgoing request.
 type RequestMutatorFunc func(incoming, outgoing *http.Request) *http.Request
@@ -116,7 +109,7 @@ func WithTimeWait(t int32) Option {
 // JSON as the content encoding.
 //
 // The HTTP Authorization header is either populated from the Sec-Websocket-Protocol field or by a cookie.
-// The cookie name is specified by the TokenCookieName value.
+// The cookie name defaults to "token" and can be overridden with WithTokenCookieName.
 //
 // example:
 //
@@ -126,12 +119,12 @@ func WithTimeWait(t int32) Option {
 //
 //	Authorization: Bearer foobar
 //
-// Method can be overwritten with the MethodOverrideParam get parameter in the requested URL
+// Method can be overwritten with the method query parameter (default "method") in the requested URL.
 func WebsocketProxy(h http.Handler, opts ...Option) http.Handler {
 	p := &Proxy{
 		h:                   h,
-		methodOverrideParam: MethodOverrideParam,
-		tokenCookieName:     TokenCookieName,
+		methodOverrideParam: defaultMethodOverrideParam,
+		tokenCookieName:     defaultTokenCookieName,
 	}
 	for _, o := range opts {
 		o(p)

--- a/servers/gatewayserver/config.go
+++ b/servers/gatewayserver/config.go
@@ -2,7 +2,6 @@ package gatewayserver
 
 import (
 	"github.com/pubgo/funk/v2/config"
-	"github.com/pubgo/funk/v2/log"
 	"github.com/pubgo/funk/v2/merge"
 
 	"github.com/pubgo/lava/v2/pkg/fiberbuilder"
@@ -18,44 +17,20 @@ type ConfigLoader struct {
 	GatewayServer *Config `yaml:"gateway_server"`
 }
 
-// GrpcServerConfigLoader is a legacy alias for grpc_server YAML key.
-type GrpcServerConfigLoader struct {
-	GrpcServer *Config `yaml:"grpc_server"`
-}
-
-// CombinedConfigLoader loads gateway_server and legacy grpc_server keys from YAML.
-type CombinedConfigLoader struct {
-	GatewayServer *Config `yaml:"gateway_server"`
-	GrpcServer    *Config `yaml:"grpc_server"`
-}
-
-// ResolveConfig merges YAML loaders, preferring gateway_server and warning on legacy grpc_server.
-func ResolveConfig(loader CombinedConfigLoader, logger log.Logger) *Config {
-	switch {
-	case loader.GatewayServer != nil && loader.GrpcServer != nil:
-		if logger != nil {
-			logger.Warn().Msg("both gateway_server and grpc_server are set; gateway_server wins — remove grpc_server from YAML")
-		}
+func ResolveConfig(loader ConfigLoader) *Config {
+	if loader.GatewayServer != nil {
 		return merge.Struct(defaultCfg(), loader.GatewayServer).Unwrap()
-	case loader.GatewayServer != nil:
-		return merge.Struct(defaultCfg(), loader.GatewayServer).Unwrap()
-	case loader.GrpcServer != nil:
-		if logger != nil {
-			logger.Warn().Msg("yaml key grpc_server is deprecated; rename to gateway_server (see docs/legacy-removal.md)")
-		}
-		return merge.Struct(defaultCfg(), loader.GrpcServer).Unwrap()
-	default:
-		return defaultCfg()
 	}
+	return defaultCfg()
 }
 
 // LoadConfig reads gateway settings from the active funk config path, if any.
-func LoadConfig(logger log.Logger) *Config {
+func LoadConfig() *Config {
 	if config.GetConfigPath() == "" {
 		return defaultCfg()
 	}
-	loaded := config.Load[CombinedConfigLoader]()
-	return ResolveConfig(loaded.T, logger)
+	loaded := config.Load[ConfigLoader]()
+	return ResolveConfig(loaded.T)
 }
 
 // Config holds HTTP/REST, WebSocket, and native gRPC gateway server settings.
@@ -71,13 +46,8 @@ type Config struct {
 	WebSocketOriginPatterns []string `yaml:"websocket_origin_patterns"`
 	// WebSocketInsecureSkipVerify disables WS origin checks (development only).
 	WebSocketInsecureSkipVerify bool `yaml:"websocket_insecure_skip_verify"`
-	// Default is true: register handlers on Mux only; native gRPC uses passthrough.
-	// Set false for legacy dual registration on Mux and grpc.Server.
-	GRPCPassthrough bool `yaml:"grpc_passthrough"`
 }
 
 func defaultCfg() *Config {
-	return &Config{
-		GRPCPassthrough: true,
-	}
+	return &Config{}
 }

--- a/servers/gatewayserver/config_test.go
+++ b/servers/gatewayserver/config_test.go
@@ -1,47 +1,23 @@
 package gatewayserver
 
-import (
-	"testing"
-
-	"github.com/pubgo/funk/v2/log"
-)
+import "testing"
 
 func TestResolveConfigPrefersGatewayServer(t *testing.T) {
 	t.Parallel()
 
-	cfg := ResolveConfig(CombinedConfigLoader{
+	cfg := ResolveConfig(ConfigLoader{
 		GatewayServer: &Config{EnablePrintRouter: true},
-		GrpcServer:    &Config{EnablePrintRouter: false},
-	}, nil)
+	})
 	if !cfg.EnablePrintRouter {
-		t.Fatal("expected gateway_server to win")
-	}
-}
-
-func TestResolveConfigLegacyGrpcServer(t *testing.T) {
-	t.Parallel()
-
-	cfg := ResolveConfig(CombinedConfigLoader{
-		GrpcServer: &Config{EnablePrintRouter: true},
-	}, log.GetLogger("test"))
-	if !cfg.EnablePrintRouter {
-		t.Fatal("expected legacy grpc_server config to apply")
+		t.Fatal("expected gateway_server config to apply")
 	}
 }
 
 func TestResolveConfigDefaults(t *testing.T) {
 	t.Parallel()
 
-	cfg := ResolveConfig(CombinedConfigLoader{}, nil)
-	if !cfg.GRPCPassthrough {
-		t.Fatal("expected default grpc_passthrough true")
-	}
-}
-
-func TestDefaultCfgGRPCPassthrough(t *testing.T) {
-	t.Parallel()
-	cfg := defaultCfg()
-	if !cfg.GRPCPassthrough {
-		t.Fatal("expected grpc_passthrough default true")
+	cfg := ResolveConfig(ConfigLoader{})
+	if cfg.EnablePrintRouter {
+		t.Fatal("expected enable_print_router default false")
 	}
 }

--- a/servers/gatewayserver/server.go
+++ b/servers/gatewayserver/server.go
@@ -173,29 +173,11 @@ func (s *serviceImpl) init(
 	mux.SetUnaryInterceptor(handlerUnaryMiddle(srvMidMap))
 	mux.SetStreamInterceptor(handlerStreamMiddle(srvMidMap))
 
-	var grpcServerOpts []grpc.ServerOption
-	if conf.GRPCPassthrough {
-		// Middleware runs on Mux (SetUnaryInterceptor); outer grpc.Server only passthroughs.
-		grpcServerOpts = mux.GRPCServerOptions()
-		log.Info().Msg("gateway grpc passthrough enabled: register services on Mux only")
-	} else {
-		grpcServerOpts = []grpc.ServerOption{
-			grpc.ChainUnaryInterceptor(handlerUnaryMiddle(srvMidMap)),
-			grpc.ChainStreamInterceptor(handlerStreamMiddle(srvMidMap)),
-		}
-		log.Warn().Msg("gateway grpc passthrough disabled: services registered on both Mux and grpc.Server (legacy mode; set grpc_passthrough: true)")
-	}
+	// Middleware runs on Mux (SetUnaryInterceptor); outer grpc.Server only passthroughs.
+	grpcServerOpts := mux.GRPCServerOptions()
+	log.Info().Msg("gateway grpc passthrough: register services on Mux only")
 
 	grpcServer := conf.GrpcConfig.Build(grpcServerOpts...).Expect("failed to build grpc server")
-
-	if !conf.GRPCPassthrough {
-		for _, h := range grpcRouters {
-			grpcServer.RegisterService(h.ServiceDesc(), h)
-		}
-		for _, h := range grpcHttpRouters {
-			grpcServer.RegisterService(h.ServiceDesc(), h)
-		}
-	}
 
 	gatewayAPIPrefix := "/api"
 	log.Info().Str("prefix", gatewayAPIPrefix).Msg("gateway HTTP base path")


### PR DESCRIPTION
## Summary
v2 尚未正式发布，本 PR 一次性移除原计划保留到 v3 的兼容层：

- 删除 `grpc_server` YAML 键解析，仅保留 `gateway_server`
- 删除 `grpc_passthrough: false` 双注册模式，固定 Mux-only + 原生 gRPC 透传
- 删除 `pkg/wsproxy` 包级 `MethodOverrideParam` / `TokenCookieName`（改用内部默认值 + Option）
- 删除 `pkg/netutil.HasLocalIPddr` 拼写错误别名
- 更新 `docs/legacy-removal.md` 与相关文档

## Breaking changes
- 配置文件：`grpc_server:` → `gateway_server:`
- 配置项：移除 `grpc_passthrough`（行为固定为透传）
- API：移除 `HasLocalIPddr`，使用 `HasLocalIPAddr`
- API：移除 `wsproxy.MethodOverrideParam` / `wsproxy.TokenCookieName`

## Supersedes
- #153 / #154 / #155（合并为本 PR）

## Test plan
- [x] `go test -short -race ./...`


Made with [Cursor](https://cursor.com)